### PR TITLE
Fix broken parameters merge

### DIFF
--- a/ocdeployer/__main__.py
+++ b/ocdeployer/__main__.py
@@ -15,7 +15,7 @@ import shutil
 import prompter
 import yaml
 
-from ocdeployer.utils import oc, load_cfg_file, get_routes, switch_to_project
+from ocdeployer.utils import object_merge, oc, load_cfg_file, get_routes, switch_to_project
 from ocdeployer.secrets import SecretImporter
 from ocdeployer.deploy import DeployRunner
 
@@ -95,24 +95,6 @@ def list_sets(template_dir, output=None):
         print(yaml.dump(as_dict, default_flow_style=False))
 
 
-def object_merge(old, new):
-    """
-    Recursively merge two data structures
-
-    Thanks rsnyman :)
-    https://github.com/rochacbruno/dynaconf/commit/458ffa6012f1de62fc4f68077f382ab420b43cfc#diff-c1b434836019ae32dc57d00dd1ae2eb9R15
-    """
-    if isinstance(old, list) and isinstance(new, list):
-        for item in old[::-1]:
-            new.insert(0, item)
-    if isinstance(old, dict) and isinstance(new, dict):
-        for key, value in old.items():
-            if key not in new:
-                new[key] = value
-            else:
-                object_merge(value, new[key])
-
-
 def get_variables_data(variables_files):
     variables_data = load_cfg_file(variables_files[0])
 
@@ -120,8 +102,7 @@ def get_variables_data(variables_files):
     if len(variables_files) > 1:
         for var_file in variables_files[1:]:
             merged_file_data = load_cfg_file(var_file)
-            object_merge(variables_data, merged_file_data)
-            variables_data = merged_file_data
+            object_merge(merged_file_data, variables_data)
 
     # Check if there's any variables we need to prompt for
     for section, data in variables_data.items():

--- a/ocdeployer/deploy.py
+++ b/ocdeployer/deploy.py
@@ -7,7 +7,7 @@ import logging
 import os
 import sys
 
-from .utils import load_cfg_file, oc, wait_for_ready_threaded, get_json
+from .utils import load_cfg_file, object_merge, oc, wait_for_ready_threaded, get_json
 from .secrets import SecretImporter
 from .templates import get_templates_in_dir
 
@@ -219,8 +219,8 @@ class DeployRunner(object):
         if "parameters" not in variables:
             variables["parameters"] = {}
 
-        variables.update(self.variables_data.get(service_set, {}))
-        variables.update(self.variables_data.get("{}/{}".format(service_set, component), {}))
+        object_merge(self.variables_data.get(service_set, {}), variables)
+        object_merge(self.variables_data.get("{}/{}".format(service_set, component), {}), variables)
 
         # ocdeployer adds the "NAMESPACE" parameter by default at deploy time
         variables["parameters"].update({"NAMESPACE": self.project_name})

--- a/ocdeployer/templates.py
+++ b/ocdeployer/templates.py
@@ -161,23 +161,25 @@ class Template(object):
         for param_name, param_value in parameters.items():
             params_and_vals[param_name] = "{}={}".format(param_name, param_value)
 
-        log.info(
-            "Running 'oc process' on template '%s' with parameters '%s'",
-            self.file_name,
-            ", ".join([string for _, string in params_and_vals.items()]),
-        )
-
         extra_args = []
         # Only insert the parameter if it was defined in the template
         param_names_defined_in_template = [
             param.get("name") for param in content.get("parameters", [])
         ]
         skipped_params = []
+        params_and_vals_used = []
         for param_name, string in params_and_vals.items():
             if param_name in param_names_defined_in_template:
                 extra_args.extend(["-p", string])
+                params_and_vals_used.append(string)
             else:
                 skipped_params.append(param_name)
+
+        log.info(
+            "Running 'oc process' on template '%s' with parameters '%s'",
+            self.file_name,
+            ", ".join([string for string in params_and_vals_used]),
+        )
 
         if skipped_params:
             log.warning(

--- a/ocdeployer/utils.py
+++ b/ocdeployer/utils.py
@@ -42,6 +42,24 @@ SHORTCUTS = {
 }
 
 
+def object_merge(old, new):
+    """
+    Recursively merge two data structures
+
+    Thanks rsnyman :)
+    https://github.com/rochacbruno/dynaconf/commit/458ffa6012f1de62fc4f68077f382ab420b43cfc#diff-c1b434836019ae32dc57d00dd1ae2eb9R15
+    """
+    if isinstance(old, list) and isinstance(new, list):
+        for item in old[::-1]:
+            new.insert(0, item)
+    if isinstance(old, dict) and isinstance(new, dict):
+        for key, value in old.items():
+            if key not in new:
+                new[key] = value
+            else:
+                object_merge(value, new[key])
+
+
 def parse_restype(string):
     """
     Given a resource type or its shortcut, return the full resource type name.


### PR DESCRIPTION
The `.update` calls were overwriting `parameters` since the update was not recursive. Switched to using `object_merge` to recursively merge the dictionaries.