### PR TITLE
Fix the env file override logic and add tests

### DIFF
--- a/ocdeployer/deploy.py
+++ b/ocdeployer/deploy.py
@@ -296,13 +296,12 @@ class DeployRunner(object):
         Returns:
             dict of variables/values to apply to this specific component
         """
-        variables = copy.deepcopy(self.variables_data.get("global", {}))
-
+        variables = copy.deepcopy(self.variables_data.get("{}/{}".format(service_set, component), {}))
         if "parameters" not in variables:
             variables["parameters"] = {}
 
         object_merge(self.variables_data.get(service_set, {}), variables)
-        object_merge(self.variables_data.get("{}/{}".format(service_set, component), {}), variables)
+        object_merge(self.variables_data.get("global", {}), variables)
 
         # ocdeployer adds the "NAMESPACE" parameter by default at deploy time
         variables["parameters"].update({"NAMESPACE": self.project_name})

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -1,0 +1,156 @@
+import ocdeployer
+import ocdeployer.deploy
+
+import pytest
+
+def runner(variables_data):
+    return ocdeployer.deploy.DeployRunner(
+               None,
+               "test-project",
+               variables_data,
+               None,
+               None,
+               None,
+               None
+           )
+
+def test__get_variables_sanity():
+    variables_data = {
+        "service": {
+            "enable_routes": False,
+            "enable_db": False,
+            "parameters": {
+                "STUFF": "things"
+            }
+        }
+    }
+    expected = {
+        "enable_routes": False,
+        "enable_db": False,
+        "parameters": {
+            "STUFF": "things",
+            "NAMESPACE": "test-project"
+        }
+    }
+    assert runner(variables_data)._get_variables("service", []) == expected
+
+def test__get_variables_merge_from_global():
+    variables_data = {
+        "global": {
+            "global_variable": "global-value",
+            "parameters": {
+                "GLOBAL": "things"
+            }
+        },
+        "service": {
+            "service_variable": True,
+            "parameters": {
+                "STUFF": "service-stuff"
+            }
+        },
+        "service/component": {
+            "component_variable": "component",
+            "parameters": {
+                "COMPONENT": "component-param"
+            }
+        }
+    }
+
+    expected = {
+        "component_variable": "component",
+        "global_variable": "global-value",
+        "service_variable": True,
+        "parameters": {
+            "COMPONENT": "component-param",
+            "GLOBAL": "things",
+            "STUFF": "service-stuff",
+            "NAMESPACE": "test-project"
+        }
+    }
+    assert runner(variables_data)._get_variables("service", "component") == expected
+
+def test__get_variables_service_overwrite_parameter():
+    variables_data = {
+        "global": {
+            "parameters": {
+                "STUFF": "things"
+            }
+        },
+        "service": {
+            "parameters": {
+                "STUFF": "service-stuff"
+            }
+        }
+    }
+    expected = {
+        "parameters": {
+            "STUFF": "service-stuff",
+            "NAMESPACE": "test-project"
+        }
+    }
+    assert runner(variables_data)._get_variables("service", []) == expected
+
+def test__get_variables_service_overwrite_variable():
+    variables_data = {
+        "global": {
+            "enable_db": False
+        },
+        "service": {
+            "enable_db": True
+        }
+    }
+    expected = {
+        "enable_db": True,
+        "parameters": {
+            "NAMESPACE": "test-project"
+        }
+    }
+    assert runner(variables_data)._get_variables("service", []) == expected
+
+def test__get_variables_component_overwrite_parameter():
+    variables_data = {
+        "global": {
+            "parameters": {
+                "STUFF": "things"
+            }
+        },
+        "service": {
+            "parameters": {
+                "THINGS": "service-things"
+            }
+        },
+        "service/component": {
+            "parameters": {
+                "THINGS": "component-things"
+            }
+        }
+    }
+    expected = {
+        "parameters": {
+            "STUFF": "things",
+            "THINGS": "component-things",
+            "NAMESPACE": "test-project"
+        }
+    }
+    assert runner(variables_data)._get_variables("service", "component") == expected
+
+def test__get_variables_component_overwrite_variable():
+    variables_data = {
+        "global": {
+            "enable_routes": False
+        },
+        "service": {
+            "enable_db": True
+        },
+        "service/component": {
+            "enable_db": False
+        }
+    }
+    expected = {
+        "enable_routes": False,
+        "enable_db": False,
+        "parameters": {
+            "NAMESPACE": "test-project"
+        }
+    }
+    assert runner(variables_data)._get_variables("service", "component") == expected

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,36 @@
+import ocdeployer
+import ocdeployer.utils as utils
+
+import pytest
+
+def test_object_merge_merges_lists():
+    edit = [1, 3]
+    add = [2]
+
+    utils.object_merge(add, edit)
+
+    assert edit == [2, 1, 3]
+
+def test_obect_merge_merges_dicts():
+    edit = {"thing": "stuff"}
+    add = {"test": "add"}
+
+    utils.object_merge(add, edit)
+
+    assert edit == {"thing": "stuff", "test": "add"}
+
+def test_object_merge_keeps_original_dict_keys():
+    edit = {"thing": 3}
+    add = {"thing": 1}
+
+    utils.object_merge(add, edit)
+
+    assert edit == {"thing": 3}
+
+def test_object_merge_recursively_merges_dicts():
+    edit = {"things": {"stuff": 1}}
+    add = {"things": {"new": 2}}
+
+    utils.object_merge(add, edit)
+
+    assert edit == {"things": {"stuff": 1, "new": 2}}


### PR DESCRIPTION
Previously the override logic was exactly backwards so
the global would have priority over the service which had priority
over the component.

This commit reverses them and adds unit tests for the methods involved

@bsquizz I don't know if this is really how you would want to organize the test framework, but we can iterate on that. I just wanted something here to preserve my sanity.