### PR TITLE
Pass SECRETS_PROJECT to templates at deploy time

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,8 +354,13 @@ To use the secrets files in your next project deploy:
 ```
 
 ## Environment file
-By default, the 'NAMESPACE' parameter is passed to all templates which corresponds to the project name. You can also define an "environment"
-file with more detailed variable information. Here is an example:
+By default, the following parameters are passed to templates by ocdeployer at deploy time:
+
+* 'NAMESPACE' corresponds to the project name selected on the CLI.
+* 'SECRETS_PROJECT' corresponds to the secrets-source-project selected on the CLI (default: "secrets")
+
+
+You can also define an "environment" file with more customized variable information. Here is an example:
 
 ```yaml
 global:

--- a/README.md
+++ b/README.md
@@ -357,7 +357,7 @@ To use the secrets files in your next project deploy:
 By default, the following parameters are passed to templates by ocdeployer at deploy time:
 
 * 'NAMESPACE' corresponds to the project name selected on the CLI.
-* 'SECRETS_PROJECT' corresponds to the secrets-source-project selected on the CLI (default: "secrets")
+* 'SECRETS_PROJECT' corresponds to the secrets-src-project selected on the CLI (default: "secrets")
 
 
 You can also define an "environment" file with more customized variable information. Here is an example:

--- a/ocdeployer/deploy.py
+++ b/ocdeployer/deploy.py
@@ -301,8 +301,13 @@ class DeployRunner(object):
         variables = object_merge(self.variables_data.get(service_set, {}), variables)
         variables = object_merge(self.variables_data.get("global", {}), variables)
 
-        # ocdeployer adds the "NAMESPACE" parameter by default at deploy time
-        variables["parameters"].update({"NAMESPACE": self.project_name})
+        # ocdeployer adds the "NAMESPACE" and "SECRETS_PROJECT" parameter by default at deploy time
+        variables["parameters"].update(
+            {
+                "NAMESPACE": self.project_name,
+                "SECRETS_PROJECT": SecretImporter.source_project
+            }
+        )
 
         return variables
 

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -58,7 +58,7 @@ def test__get_variables_service_overwrite_parameter():
         "parameters": {
             "STUFF": "service-stuff",
             "NAMESPACE": "test-project",
-            "SECRETS_PROJECT": SecretImporter.source_project}
+            "SECRETS_PROJECT": SecretImporter.source_project
         }
     }
     assert runner(variables_data)._get_variables("service", []) == expected

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -1,4 +1,5 @@
 import ocdeployer.deploy
+from ocdeployer.secrets import SecretImporter
 
 
 def runner(variables_data):
@@ -14,7 +15,11 @@ def test__get_variables_sanity():
     expected = {
         "enable_routes": False,
         "enable_db": False,
-        "parameters": {"STUFF": "things", "NAMESPACE": "test-project"},
+        "parameters": {
+            "STUFF": "things",
+            "NAMESPACE": "test-project",
+            "SECRETS_PROJECT": SecretImporter.source_project
+        },
     }
     assert runner(variables_data)._get_variables("service", []) == expected
 
@@ -38,6 +43,7 @@ def test__get_variables_merge_from_global():
             "GLOBAL": "things",
             "STUFF": "service-stuff",
             "NAMESPACE": "test-project",
+            "SECRETS_PROJECT": SecretImporter.source_project
         },
     }
     assert runner(variables_data)._get_variables("service", "component") == expected
@@ -48,13 +54,25 @@ def test__get_variables_service_overwrite_parameter():
         "global": {"parameters": {"STUFF": "things"}},
         "service": {"parameters": {"STUFF": "service-stuff"}},
     }
-    expected = {"parameters": {"STUFF": "service-stuff", "NAMESPACE": "test-project"}}
+    expected = {
+        "parameters": {
+            "STUFF": "service-stuff",
+            "NAMESPACE": "test-project",
+            "SECRETS_PROJECT": SecretImporter.source_project}
+        }
+    }
     assert runner(variables_data)._get_variables("service", []) == expected
 
 
 def test__get_variables_service_overwrite_variable():
     variables_data = {"global": {"enable_db": False}, "service": {"enable_db": True}}
-    expected = {"enable_db": True, "parameters": {"NAMESPACE": "test-project"}}
+    expected = {
+        "enable_db": True,
+        "parameters": {
+            "NAMESPACE": "test-project",
+            "SECRETS_PROJECT": SecretImporter.source_project
+        }
+    }
     assert runner(variables_data)._get_variables("service", []) == expected
 
 
@@ -65,7 +83,12 @@ def test__get_variables_component_overwrite_parameter():
         "service/component": {"parameters": {"THINGS": "component-things"}},
     }
     expected = {
-        "parameters": {"STUFF": "things", "THINGS": "component-things", "NAMESPACE": "test-project"}
+        "parameters": {
+            "STUFF": "things",
+            "THINGS": "component-things",
+            "NAMESPACE": "test-project",
+            "SECRETS_PROJECT": SecretImporter.source_project
+        }
     }
     assert runner(variables_data)._get_variables("service", "component") == expected
 
@@ -79,6 +102,9 @@ def test__get_variables_component_overwrite_variable():
     expected = {
         "enable_routes": False,
         "enable_db": False,
-        "parameters": {"NAMESPACE": "test-project"},
+        "parameters": {
+            "NAMESPACE": "test-project",
+            "SECRETS_PROJECT": SecretImporter.source_project
+        },
     }
     assert runner(variables_data)._get_variables("service", "component") == expected


### PR DESCRIPTION
Pre-deploy/post-deploy scripts and templates have no knowledge of which secrets namespace was selected at runtime. Passing this parameter in by default makes that info accessible to them. 