### PR TITLE
Print OCP server url before run wipe/deploy commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# IDE
+.idea

--- a/ocdeployer/__main__.py
+++ b/ocdeployer/__main__.py
@@ -44,7 +44,7 @@ def wipe(no_confirm, project, label):
         extra_msg = " with label '{}'".format(label)
 
     if not no_confirm and prompter.yesno(
-        "I'm about to delete everything in project '{}'{} on server {}Continue?".format(project, extra_msg, server),
+        "I'm about to delete everything in project '{}'{} on server {} -- continue?".format(project, extra_msg, server),
         default="no",
     ):
         sys.exit(0)
@@ -212,7 +212,7 @@ def _parse_args(template_dir, all_services, sets, pick, dst_project, env_files):
             log.error("Invalid format for '--pick', use: 'service_set/component'")
             sys.exit(1)
         sets_selected = [service_set]
-        confirm_msg = "Deploying single component '{}' to project '{}' on server {}Continue?".format(
+        confirm_msg = "Deploying single component '{}' to project '{}' on server {} -- continue?".format(
             pick, dst_project, server
         )
     else:
@@ -220,7 +220,7 @@ def _parse_args(template_dir, all_services, sets, pick, dst_project, env_files):
             sets_selected = all_sets(template_dir)
         else:
             sets_selected = sets.split(",")
-        confirm_msg = "Deploying service sets '{}' to project '{}' on server {}Continue?".format(
+        confirm_msg = "Deploying service sets '{}' to project '{}' on server {} -- continue?".format(
             ", ".join(sets_selected), dst_project, server
         )
 

--- a/ocdeployer/__main__.py
+++ b/ocdeployer/__main__.py
@@ -44,7 +44,9 @@ def wipe(no_confirm, project, label):
         extra_msg = " with label '{}'".format(label)
 
     if not no_confirm and prompter.yesno(
-        "I'm about to delete everything in project '{}'{} on server {} -- continue?".format(project, extra_msg, server),
+        "I'm about to delete everything in project '{}'{} on server {} -- continue?".format(
+            project, extra_msg, server
+        ),
         default="no",
     ):
         sys.exit(0)
@@ -212,16 +214,20 @@ def _parse_args(template_dir, all_services, sets, pick, dst_project, env_files):
             log.error("Invalid format for '--pick', use: 'service_set/component'")
             sys.exit(1)
         sets_selected = [service_set]
-        confirm_msg = "Deploying single component '{}' to project '{}' on server {} -- continue?".format(
-            pick, dst_project, server
+        confirm_msg = (
+            "Deploying single component '{}' to project '{}' on server {} -- continue?".format(
+                pick, dst_project, server
+            )
         )
     else:
         if all_services:
             sets_selected = all_sets(template_dir)
         else:
             sets_selected = sets.split(",")
-        confirm_msg = "Deploying service sets '{}' to project '{}' on server {} -- continue?".format(
-            ", ".join(sets_selected), dst_project, server
+        confirm_msg = (
+            "Deploying service sets '{}' to project '{}' on server {} -- continue?".format(
+                ", ".join(sets_selected), dst_project, server
+            )
         )
 
     if env_files:

--- a/ocdeployer/__main__.py
+++ b/ocdeployer/__main__.py
@@ -22,6 +22,7 @@ from ocdeployer.utils import (
     load_cfg_file,
     get_routes,
     switch_to_project,
+    get_server_info,
 )
 from ocdeployer.secrets import SecretImporter
 from ocdeployer.deploy import DeployRunner
@@ -37,12 +38,13 @@ CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
 
 
 def wipe(no_confirm, project, label):
+    server = get_server_info()
     extra_msg = ""
     if label:
         extra_msg = " with label '{}'".format(label)
 
     if not no_confirm and prompter.yesno(
-        "I'm about to delete everything in project '{}'{}.  Continue?".format(project, extra_msg),
+        "I'm about to delete everything in project '{}'{} on server {}Continue?".format(project, extra_msg, server),
         default="no",
     ):
         sys.exit(0)
@@ -201,6 +203,7 @@ def _parse_args(template_dir, all_services, sets, pick, dst_project, env_files):
         sys.exit(1)
 
     specific_component = None
+    server = get_server_info()
 
     if pick:
         try:
@@ -209,16 +212,16 @@ def _parse_args(template_dir, all_services, sets, pick, dst_project, env_files):
             log.error("Invalid format for '--pick', use: 'service_set/component'")
             sys.exit(1)
         sets_selected = [service_set]
-        confirm_msg = "Deploying single component '{}' to project '{}'.  Continue?".format(
-            pick, dst_project
+        confirm_msg = "Deploying single component '{}' to project '{}' on server {}Continue?".format(
+            pick, dst_project, server
         )
     else:
         if all_services:
             sets_selected = all_sets(template_dir)
         else:
             sets_selected = sets.split(",")
-        confirm_msg = "Deploying service sets '{}' to project '{}'.  Continue?".format(
-            ", ".join(sets_selected), dst_project
+        confirm_msg = "Deploying service sets '{}' to project '{}' on server {}Continue?".format(
+            ", ".join(sets_selected), dst_project, server
         )
 
     if env_files:

--- a/ocdeployer/templates.py
+++ b/ocdeployer/templates.py
@@ -42,7 +42,7 @@ def _scale_val(val, scale_factor):
     * "2" scaled by .5 returns "1"
     * "200m" scaled by 2 returns "400m"
     """
-    match = RESOURCE_REGEX.match(val)
+    match = RESOURCE_REGEX.match(str(val))
     if match:
         base_num, decimal, unit = match.groups()
     else:

--- a/ocdeployer/utils.py
+++ b/ocdeployer/utils.py
@@ -16,7 +16,6 @@ from wait_for import wait_for, TimedOutError
 
 log = logging.getLogger(__name__)
 
-
 # Resource types and their cli shortcuts
 # Mostly listed here: https://docs.openshift.com/online/cli_reference/basic_cli_operations.html
 SHORTCUTS = {
@@ -541,3 +540,8 @@ def start_deployment(dc_name, timeout=180):
         timeout=timeout,
         log_on_loop=True,
     )
+
+
+def get_server_info():
+    """Return server connected on"""
+    return oc("whoami", "--show-server", _silent=True)


### PR DESCRIPTION
when migrating data,bc,is,etc between two clusters sometimes you got lost on which cluster you have session opened on in other others where you are logged in. For few times I almost messed-up DEV cluster running wipe or even deploy command. This PR prints the server URL/address the user is logged in when running ocdeployer wipe or deploy commands.