### PR TITLE
Always re-import image streams

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,8 +204,7 @@ The best way to explain how template configuration works is to describe the proc
     #
     # 'oc import-image <key> --from="<value>"' is run at deploy time.
     #
-    # We check to make sure that an image with this name exists before importing it.
-    # If it already exists, it will not be re-imported.
+    # If it already exists, it will be re-imported (and therefore the image will be updated)
     images:
       cp-kafka: "confluentinc/cp-kafka"
       cp-zookeeper: "confluentinc/cp-zookeeper"

--- a/example/README.md
+++ b/example/README.md
@@ -136,7 +136,7 @@ If we had more sets, you could deploy only set1 and set2 with the below command.
 ## High-level steps of the deploy process
 
 `ocdeployer` essentially does the following for each service set as it deploys them:
-1) Runs `oc import-image` for any images listed in the `_cfg.yml`. NOTE: if image streams with the same name/tag already exist in the project, they will not be re-imported.
+1) Runs `oc import-image` for any images listed in the `_cfg.yml`. NOTE: if image streams with the same name/tag already exist in the project, they will be re-imported.
 2) Imports any needed secrets from the secrets local dir, or from a separate OpenShift project. NOTE: if any secrets exist with the same name in the project, they will be overwritten.
 3) Runs custom pre-deploy logic, if any is defined.
 4) For each stage, it deploys the components in the configured order. If the default `deploy` logic is not overwritten by a custom deploy method:

--- a/ocdeployer/deploy.py
+++ b/ocdeployer/deploy.py
@@ -144,9 +144,7 @@ def _handle_secrets_and_imgs(config):
 
     # Import the specified images
     for img_name, img_src in config.get("images", {}).items():
-        exists = oc("get", "is", img_name, _exit_on_err=False)
-        if not exists:
-            oc("import-image", img_name, "--from={}".format(img_src), "--confirm")
+        oc("import-image", img_name, "--from={}".format(img_src), "--confirm")
 
 
 def _get_custom_methods(service_set, custom_dir):


### PR DESCRIPTION
Previously if an image stream already existed in a namespace, we would not run "oc import-image" on it. This can be a problem when the image streams are not set to auto-update -- the image eventually gets stale.

Now we will run import-image on every deploy, which will pull the latest image referenced by the image stream into the namespace.