### PR TITLE
Support for env file hierarchy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,5 +8,5 @@ cache: pip
 install:
   - pip install -r requirements-test.txt
 script:
-  - flake8 --max-line-length 100 ocdeployer/* tests/* setup.py
+  - flake8 --max-line-length 100 ocdeployer/*.py tests/*.py setup.py
   - pytest

--- a/ocdeployer/__main__.py
+++ b/ocdeployer/__main__.py
@@ -132,11 +132,9 @@ _common_options = [
         "-e",
         "env_values",
         help=(
-            "Name of environment to load variables from (default: None)."
-            "  Use this option multiple times to concatenate environment configurations."
-            " "
-            "  You can specify specific filenames here (legacy processing), or the names of envs"
-            "  to load from the env dir (preferred method)"
+            "Name of environment to load variables from (default: None).  Use this option multiple"
+            " times to concatenate environment configurations. The env listed first takes priority."
+            "  You can also specify filenames here (see docs on legacy env file processing)."
         ),
         multiple=True,
     ),
@@ -145,11 +143,9 @@ _common_options = [
         "-n",
         default="env",
         help=(
-            "Env variables directory name (default 'env')."
-            "  This is the name of the directory in $WORKING_DIR and in each service set that env"
-            "  files will be loaded from."
-            " "
-            "  NOTE: Does not apply to legacy processing (providing specific filenames to --env)"
+            "Env variables directory name (default 'env').  This is joined"
+            " to $WORKING_DIR & each service set dir to set path for discovering env files.  NOTE:"
+            " Does not apply to legacy env file processing."
         ),
     ),
     click.option(

--- a/ocdeployer/__main__.py
+++ b/ocdeployer/__main__.py
@@ -17,9 +17,7 @@ import yaml
 
 from ocdeployer.utils import (
     all_sets,
-    object_merge,
     oc,
-    load_cfg_file,
     get_routes,
     switch_to_project,
     get_server_info,

--- a/ocdeployer/deploy.py
+++ b/ocdeployer/deploy.py
@@ -9,6 +9,9 @@ import os
 import sys
 import yaml
 
+from cached_property import cached_property
+
+from .env import get_base_env_config
 from .utils import load_cfg_file, object_merge, oc, wait_for_ready_threaded
 from .secrets import SecretImporter
 from .templates import get_templates_in_dir
@@ -241,7 +244,7 @@ class DeployRunner(object):
         self,
         template_dir,
         project_name,
-        variables_data,
+        env_names,
         ignore_requires,
         service_sets_selected,
         resources_scale_factor,
@@ -255,7 +258,7 @@ class DeployRunner(object):
         self.template_dir = template_dir
         self.custom_dir = custom_dir
         self.project_name = project_name
-        self.variables_data = variables_data or {}
+        self.env_names = env_names or []
         self.ignore_requires = ignore_requires
         self.service_sets_selected = service_sets_selected
         self.resources_scale_factor = resources_scale_factor
@@ -265,6 +268,10 @@ class DeployRunner(object):
         self.skip = skip
         self.dry_run = dry_run
         self.dry_run_opts = dry_run_opts or {}
+
+    @cached_property
+    def _base_config(self):
+        return get_base_env_config("env")
 
     def _get_variables(self, service_set, component):
         """

--- a/ocdeployer/deploy.py
+++ b/ocdeployer/deploy.py
@@ -1,7 +1,6 @@
 """
 Handles deploy logic for components
 """
-import copy
 import importlib
 import json
 import logging
@@ -9,10 +8,8 @@ import os
 import sys
 import yaml
 
-from cached_property import cached_property
-
 from .env import EnvConfigHandler
-from .utils import load_cfg_file, object_merge, oc, wait_for_ready_threaded
+from .utils import load_cfg_file, oc, wait_for_ready_threaded
 from .secrets import SecretImporter
 from .templates import get_templates_in_dir
 

--- a/ocdeployer/env.py
+++ b/ocdeployer/env.py
@@ -1,0 +1,76 @@
+import copy
+import os
+from collections import defaultdict
+
+from cached_property import cached_property
+
+from .utils import get_cfg_files_in_dir, load_cfg_file, object_merge
+
+
+GLOBAL = "global"
+
+
+def nested_dict():
+    return defaultdict(nested_dict)
+
+
+def default_to_regular(d):
+    if isinstance(d, defaultdict):
+        d = {k: default_to_regular(v) for k, v in d.items()}
+    return d
+
+
+class EnvConfigHandler:
+    def __init__(self, env_names):
+        self.env_names = env_names
+
+    def get_base_env_config(self, env_dir_path):
+        env_files = get_cfg_files_in_dir(env_dir_path)
+
+        data = nested_dict()
+
+        for file_path in env_files:
+            env_data = load_cfg_file(file_path)
+            env_name = os.path.splitext(os.path.basename(file_path))[0]
+
+            for key, config in env_data.items():
+                if '/' in key:
+                    service_set = key.split('/')[0]
+                    component = key.split('/')[1]
+                    data[env_name][service_set][component] = config
+                else:
+                    service_set = key
+                    data[env_name][service_set][GLOBAL] = config
+
+        return default_to_regular(data)
+
+    @cached_property
+    def base_env_config(self):
+        return self.get_base_env_config("env")
+
+    def _merge_config(self, service_set_config):
+        # Merge the service set config into the base config
+        merged_data = object_merge(copy.deepcopy(self.base_env_config), service_set_config)[self.env_names[0]]
+
+        # If multiple env's were listed, merge the configs of those together
+        if len(self.env_names) > 1:
+            for _, env_data in self.env_names[:1]:
+                object_merge(merged_data, env_data)
+
+        return merged_data
+
+    def get_service_set_env_config(self, env_dir_path, service_set):
+        env_files = get_cfg_files_in_dir(env_dir_path)
+
+        data = nested_dict
+
+        for file_path in env_files:
+            env_data = load_cfg_file(file_path)
+            env_name = os.path.splitext(os.path.basename(file_path))[0]
+
+            for key, config in env_data.items():
+                if '/' in key:
+                    raise ValueError("Section names inside service set env config cannot contain '/'")
+                data[env_name][service_set][GLOBAL] = config
+
+        return self._merge_config(default_to_regular(data))

--- a/ocdeployer/env.py
+++ b/ocdeployer/env.py
@@ -10,67 +10,196 @@ from .utils import get_cfg_files_in_dir, load_cfg_file, object_merge
 GLOBAL = "global"
 
 
+def convert_to_regular_dict(data):
+    if isinstance(data, defaultdict):
+        data = {key: convert_to_regular_dict(val) for key, val in data.items()}
+    return data
+
+
 def nested_dict():
     return defaultdict(nested_dict)
 
 
-def default_to_regular(d):
-    if isinstance(d, defaultdict):
-        d = {k: default_to_regular(v) for k, v in d.items()}
-    return d
-
-
 class EnvConfigHandler:
     def __init__(self, env_names):
+        self.base_env_path = "env"
         self.env_names = env_names
+        self._last_service_set = None
+        self._last_merged_vars = None
 
-    def get_base_env_config(self, env_dir_path):
+    def _load_vars_per_env(self, env_dir_path):
+        data = {}
+
         env_files = get_cfg_files_in_dir(env_dir_path)
+
+        for file_path in env_files:
+            env_name = os.path.splitext(os.path.basename(file_path))[0]
+            if env_name not in self.env_names:
+                continue
+
+            data[env_name] = load_cfg_file(file_path)
+
+        return data
+
+    def _get_base_vars(self, env_dir_path):
+        """
+        Load variables for env files located in the root 'env' dir
+
+        Only files with a name listed in 'env_names' will be loaded.
+
+        Returns a dict with keys/vals following this structure:
+        {
+            'env': {
+                'service_set': {
+                    'component': variables
+                }
+            }
+        }
+
+        "global" is a reserved service set name and component name
+        """
+        vars_per_env = self._load_vars_per_env(env_dir_path)
 
         data = nested_dict()
 
-        for file_path in env_files:
-            env_data = load_cfg_file(file_path)
-            env_name = os.path.splitext(os.path.basename(file_path))[0]
-
-            for key, config in env_data.items():
+        for env_name, env_vars in vars_per_env.items():
+            for key, config in env_vars.items():
                 if '/' in key:
                     service_set = key.split('/')[0]
                     component = key.split('/')[1]
                     data[env_name][service_set][component] = config
                 else:
+                    # If a specific component is not given, this is a global var
                     service_set = key
-                    data[env_name][service_set][GLOBAL] = config
+                    if service_set == GLOBAL:
+                        # Global for all service sets
+                        data[env_name][GLOBAL] = config
+                    else:
+                        # Global only for service set
+                        data[env_name][service_set][GLOBAL] = config
 
-        return default_to_regular(data)
+        return convert_to_regular_dict(data)
 
     @cached_property
-    def base_env_config(self):
-        return self.get_base_env_config("env")
+    def _base_vars(self):
+        """
+        Loads the base vars as a cached property, since they only need to be loaded once.
+        """
+        return self._get_base_vars(self.base_env_path)
 
-    def _merge_config(self, service_set_config):
-        # Merge the service set config into the base config
-        merged_data = object_merge(copy.deepcopy(self.base_env_config), service_set_config)[self.env_names[0]]
+    def _merge_environments(self, data):
+        """
+        Merge vars from multiple environments together
 
-        # If multiple env's were listed, merge the configs of those together
+        Returns a dict with keys/vals following this structure:
+        {
+            'service_set': {
+                'component': variables
+            }
+        }
+
+        "global" is a reserved service set name and component name
+        """
+        merged_data = data[self.env_names[0]]
+
+        # If multiple env's are listed, merge the configs of those together
         if len(self.env_names) > 1:
             for _, env_data in self.env_names[:1]:
                 object_merge(merged_data, env_data)
 
         return merged_data
 
-    def get_service_set_env_config(self, env_dir_path, service_set):
-        env_files = get_cfg_files_in_dir(env_dir_path)
+    def _merge_service_set_vars(self, env_dir_path, service_set):
+        """
+        Combine the env vars defined in a service set's env dir with the base env vars
 
-        data = nested_dict
+        Returns a dict with keys/vals following this structure:
+        {
+            'env': {
+                'service_set': {
+                    'component': variables
+                }
+            }
+        }
 
-        for file_path in env_files:
-            env_data = load_cfg_file(file_path)
-            env_name = os.path.splitext(os.path.basename(file_path))[0]
+        "global" is a reserved service set name and component name
+        """
+        vars_per_env = self._load_vars_per_env(env_dir_path)
 
-            for key, config in env_data.items():
-                if '/' in key:
-                    raise ValueError("Section names inside service set env config cannot contain '/'")
-                data[env_name][service_set][GLOBAL] = config
+        data = nested_dict()
 
-        return self._merge_config(default_to_regular(data))
+        for env_name, env_vars in vars_per_env.items():
+            for component, variables in env_vars.items():
+                if '/' in component:
+                    # Service-set level env files should only be defining component sections, not
+                    # "service_set/component" sections ... if we find a slash then strip out
+                    # the leading service set name
+                    component = component.split('/')[1]
+                data[env_name][service_set][component] = variables
+
+        data = convert_to_regular_dict(data)
+        merged_vars = object_merge(copy.deepcopy(self._base_vars), data)
+        merged_vars = self._merge_environments(merged_vars)
+        self._last_service_set = service_set
+        self._last_merged_vars = merged_vars
+        return merged_vars
+
+    def get_vars_for_component(self, service_set_env_dir, service_set, component):
+        """
+        Handles parsing of the variables data
+
+        The base variables file is set up in the following way:
+
+        global:
+            VAR1: "blah"
+            VAR2: "blah"
+
+        advisor:
+            VAR2: "this overrides global VAR2 for only components in the advisor set"
+
+        advisor/advisor-db:
+            VAR2: "this overrides global VAR2, and advisor VAR2, for only the advisor-db component"
+
+
+        The service set variables file can be set up in the following way:
+        global:
+            VAR2: "this overrides VAR2 for all components in service set"
+        
+        advisor-db:
+            VAR2: "this overrides VAR2 for only the advisor-db component in the service set"
+
+
+        The base env vars file is merged with the service set level env vars file.
+
+        Returns:
+            dict of variables/values to apply to this specific component
+        """
+        if not self.env_names:
+            return {}
+
+        if service_set == self._last_service_set:
+            merged_vars = self._last_merged_vars
+        else:
+            merged_vars = self._merge_service_set_vars(service_set_env_dir, service_set)
+
+        from pprint import pprint
+        pprint("")
+        pprint(merged_vars)
+
+        component_level_vars = merged_vars.get(service_set, {}).get(component, {})
+        service_set_level_vars = merged_vars.get(service_set, {}).get(GLOBAL, {})
+        global_vars = merged_vars.get(GLOBAL, {})
+
+        from pprint import pprint
+        pprint(component_level_vars)
+        pprint(service_set_level_vars)
+        pprint(global_vars)
+
+        variables = copy.deepcopy(component_level_vars)
+        if "parameters" not in variables:
+            variables["parameters"] = {}
+
+        variables = object_merge(service_set_level_vars, variables)
+        variables = object_merge(global_vars, variables)
+
+        return variables

--- a/ocdeployer/env.py
+++ b/ocdeployer/env.py
@@ -207,6 +207,9 @@ class EnvConfigHandler:
 
 
 class LegacyEnvConfigHandler(EnvConfigHandler):
+    """
+    Allows use of --env in "legacy mode", i.e. pass in specific env files instead of env names.
+    """
     def __init__(self, env_files):
         self.env_files = env_files
         self._last_service_set = None

--- a/ocdeployer/env.py
+++ b/ocdeployer/env.py
@@ -164,7 +164,7 @@ class EnvConfigHandler:
         The service set variables file can be set up in the following way:
         global:
             VAR2: "this overrides VAR2 for all components in service set"
-        
+
         advisor-db:
             VAR2: "this overrides VAR2 for only the advisor-db component in the service set"
 
@@ -182,18 +182,9 @@ class EnvConfigHandler:
         else:
             merged_vars = self._merge_service_set_vars(service_set_env_dir, service_set)
 
-        from pprint import pprint
-        pprint("")
-        pprint(merged_vars)
-
         component_level_vars = merged_vars.get(service_set, {}).get(component, {})
         service_set_level_vars = merged_vars.get(service_set, {}).get(GLOBAL, {})
         global_vars = merged_vars.get(GLOBAL, {})
-
-        from pprint import pprint
-        pprint(component_level_vars)
-        pprint(service_set_level_vars)
-        pprint(global_vars)
 
         variables = copy.deepcopy(component_level_vars)
         if "parameters" not in variables:

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -1,31 +1,41 @@
+import pytest
+
 from ocdeployer.secrets import SecretImporter
 from ocdeployer.deploy import DeployRunner
+from ocdeployer.env import EnvConfigHandler, LegacyEnvConfigHandler
 
 
-def patched_runner(env_names, mock_load_vars_per_env):
-    runner = DeployRunner(
-        None, "test-project", env_names, None, None, None, None
-    )
+def patched_runner(env_values, mock_load_vars_per_env, legacy=False):
+    if legacy:
+        handler = LegacyEnvConfigHandler(env_files=env_values)
+    else:
+        handler = EnvConfigHandler(env_names=env_values)
+
+    runner = DeployRunner(None, "test-project", handler, None, None, None, None)
+    runner.base_env_path = "base/env"
     runner.env_config_handler._load_vars_per_env = mock_load_vars_per_env
     return runner
 
 
 def build_mock_loader(base_env_data, service_set_env_data={}):
-    def mock_load_vars_per_env(path):
-        if path == "env":
+    def mock_load_vars_per_env(path=None):
+        if path is None or path == "base/env":
             return base_env_data
-        if path == "service/env":
+        if path == "templates/service/env":
             return service_set_env_data
         return {}
 
     return mock_load_vars_per_env
 
 
-def test__get_variables_sanity(monkeypatch):
+@pytest.mark.parametrize("legacy", (True, False), ids=("legacy=true", "legacy=false"))
+def test__get_variables_sanity(legacy):
     mock_var_data = {
         "test_env": {
             "service": {
-                "enable_routes": False, "enable_db": False, "parameters": {"STUFF": "things"}
+                "enable_routes": False,
+                "enable_db": False,
+                "parameters": {"STUFF": "things"},
             }
         }
     }
@@ -36,15 +46,16 @@ def test__get_variables_sanity(monkeypatch):
         "parameters": {
             "STUFF": "things",
             "NAMESPACE": "test-project",
-            "SECRETS_PROJECT": SecretImporter.source_project
-        }
+            "SECRETS_PROJECT": SecretImporter.source_project,
+        },
     }
 
-    runner = patched_runner(["test_env"], build_mock_loader(mock_var_data))
-    assert runner._get_variables("service", "service/env", "some_component") == expected
+    runner = patched_runner(["test_env"], build_mock_loader(mock_var_data), legacy)
+    assert runner._get_variables("service", "templates/service", "some_component") == expected
 
 
-def test__get_variables_merge_from_global():
+@pytest.mark.parametrize("legacy", (True, False), ids=("legacy=true", "legacy=false"))
+def test__get_variables_merge_from_global(legacy):
     mock_var_data = {
         "test_env": {
             "global": {"global_variable": "global-value", "parameters": {"GLOBAL": "things"}},
@@ -52,7 +63,7 @@ def test__get_variables_merge_from_global():
             "service/component": {
                 "component_variable": "component",
                 "parameters": {"COMPONENT": "component-param"},
-            }
+            },
         }
     }
 
@@ -65,19 +76,20 @@ def test__get_variables_merge_from_global():
             "GLOBAL": "things",
             "STUFF": "service-stuff",
             "NAMESPACE": "test-project",
-            "SECRETS_PROJECT": SecretImporter.source_project
+            "SECRETS_PROJECT": SecretImporter.source_project,
         },
     }
 
-    runner = patched_runner(["test_env"], build_mock_loader(mock_var_data))
-    assert runner._get_variables("service", "service/env", "component") == expected
+    runner = patched_runner(["test_env"], build_mock_loader(mock_var_data), legacy)
+    assert runner._get_variables("service", "templates/service", "component") == expected
 
 
-def test__get_variables_service_overwrite_parameter():
+@pytest.mark.parametrize("legacy", (True, False), ids=("legacy=true", "legacy=false"))
+def test__get_variables_service_overwrite_parameter(legacy):
     mock_var_data = {
         "test_env": {
             "global": {"parameters": {"STUFF": "things"}},
-            "service": {"parameters": {"STUFF": "service-stuff"}}
+            "service": {"parameters": {"STUFF": "service-stuff"}},
         }
     }
 
@@ -85,39 +97,37 @@ def test__get_variables_service_overwrite_parameter():
         "parameters": {
             "STUFF": "service-stuff",
             "NAMESPACE": "test-project",
-            "SECRETS_PROJECT": SecretImporter.source_project
+            "SECRETS_PROJECT": SecretImporter.source_project,
         }
     }
 
-    runner = patched_runner(["test_env"], build_mock_loader(mock_var_data))
-    assert runner._get_variables("service", "service/env", "component") == expected
+    runner = patched_runner(["test_env"], build_mock_loader(mock_var_data), legacy)
+    assert runner._get_variables("service", "templates/service", "component") == expected
 
 
-def test__get_variables_service_overwrite_variable():
-    mock_var_data = {
-        "test_env": {
-            "global": {"enable_db": False}, "service": {"enable_db": True}
-        }
-    }
+@pytest.mark.parametrize("legacy", (True, False), ids=("legacy=true", "legacy=false"))
+def test__get_variables_service_overwrite_variable(legacy):
+    mock_var_data = {"test_env": {"global": {"enable_db": False}, "service": {"enable_db": True}}}
 
     expected = {
         "enable_db": True,
         "parameters": {
             "NAMESPACE": "test-project",
-            "SECRETS_PROJECT": SecretImporter.source_project
-        }
+            "SECRETS_PROJECT": SecretImporter.source_project,
+        },
     }
 
-    runner = patched_runner(["test_env"], build_mock_loader(mock_var_data))
-    assert runner._get_variables("service", "service/env", "component") == expected
+    runner = patched_runner(["test_env"], build_mock_loader(mock_var_data), legacy)
+    assert runner._get_variables("service", "templates/service", "component") == expected
 
 
-def test__get_variables_component_overwrite_parameter():
+@pytest.mark.parametrize("legacy", (True, False), ids=("legacy=true", "legacy=false"))
+def test__get_variables_component_overwrite_parameter(legacy):
     mock_var_data = {
         "test_env": {
             "global": {"parameters": {"STUFF": "things"}},
             "service": {"parameters": {"THINGS": "service-things"}},
-            "service/component": {"parameters": {"THINGS": "component-things"}}
+            "service/component": {"parameters": {"THINGS": "component-things"}},
         }
     }
 
@@ -126,15 +136,16 @@ def test__get_variables_component_overwrite_parameter():
             "STUFF": "things",
             "THINGS": "component-things",
             "NAMESPACE": "test-project",
-            "SECRETS_PROJECT": SecretImporter.source_project
+            "SECRETS_PROJECT": SecretImporter.source_project,
         }
     }
 
-    runner = patched_runner(["test_env"], build_mock_loader(mock_var_data))
-    assert runner._get_variables("service", "service/env", "component") == expected
+    runner = patched_runner(["test_env"], build_mock_loader(mock_var_data), legacy)
+    assert runner._get_variables("service", "templates/service", "component") == expected
 
 
-def test__get_variables_component_overwrite_variable():
+@pytest.mark.parametrize("legacy", (True, False), ids=("legacy=true", "legacy=false"))
+def test__get_variables_component_overwrite_variable(legacy):
     mock_var_data = {
         "test_env": {
             "global": {"enable_routes": False},
@@ -148,12 +159,12 @@ def test__get_variables_component_overwrite_variable():
         "enable_db": False,
         "parameters": {
             "NAMESPACE": "test-project",
-            "SECRETS_PROJECT": SecretImporter.source_project
+            "SECRETS_PROJECT": SecretImporter.source_project,
         },
     }
 
-    runner = patched_runner(["test_env"], build_mock_loader(mock_var_data))
-    assert runner._get_variables("service", "service/env", "component") == expected
+    runner = patched_runner(["test_env"], build_mock_loader(mock_var_data), legacy)
+    assert runner._get_variables("service", "templates/service", "component") == expected
 
 
 def test__get_variables_base_and_service_set():
@@ -166,7 +177,7 @@ def test__get_variables_base_and_service_set():
     service_set_var_data = {
         "test_env": {
             "global": {"global_set_var": "set_global", "parameters": {"PARAM": "something"}},
-            "component": {"component_var": "something", "parameters": {"ANOTHER_PARAM": "stuff"}}
+            "component": {"component_var": "something", "parameters": {"ANOTHER_PARAM": "stuff"}},
         }
     }
 
@@ -179,12 +190,12 @@ def test__get_variables_base_and_service_set():
             "PARAM": "something",
             "ANOTHER_PARAM": "stuff",
             "NAMESPACE": "test-project",
-            "SECRETS_PROJECT": SecretImporter.source_project
-        }
+            "SECRETS_PROJECT": SecretImporter.source_project,
+        },
     }
 
     runner = patched_runner(["test_env"], build_mock_loader(base_var_data, service_set_var_data))
-    assert runner._get_variables("service", "service/env", "component") == expected
+    assert runner._get_variables("service", "templates/service", "component") == expected
 
 
 def test__get_variables_service_set_only():
@@ -193,7 +204,7 @@ def test__get_variables_service_set_only():
     service_set_var_data = {
         "test_env": {
             "global": {"global_set_var": "set_global", "parameters": {"PARAM": "something"}},
-            "component": {"component_var": "something", "parameters": {"ANOTHER_PARAM": "stuff"}}
+            "component": {"component_var": "something", "parameters": {"ANOTHER_PARAM": "stuff"}},
         }
     }
 
@@ -204,12 +215,12 @@ def test__get_variables_service_set_only():
             "PARAM": "something",
             "ANOTHER_PARAM": "stuff",
             "NAMESPACE": "test-project",
-            "SECRETS_PROJECT": SecretImporter.source_project
-        }
+            "SECRETS_PROJECT": SecretImporter.source_project,
+        },
     }
 
     runner = patched_runner(["test_env"], build_mock_loader(base_var_data, service_set_var_data))
-    assert runner._get_variables("service", "service/env", "component") == expected
+    assert runner._get_variables("service", "templates/service", "component") == expected
 
 
 def test__get_variables_service_set_overrides():
@@ -217,14 +228,14 @@ def test__get_variables_service_set_overrides():
         "test_env": {
             "global": {"global_var": "base_global", "parameters": {"GLOBAL_PARAM": "things"}},
             "service": {"global_set_var": "blah", "parameters": {"PARAM": "blah"}},
-            "service/component": {"component_var": "override this"}
+            "service/component": {"component_var": "override this"},
         }
     }
 
     service_set_var_data = {
         "test_env": {
             "global": {"global_set_var": "set_global", "parameters": {"PARAM": "something"}},
-            "component": {"component_var": "something", "parameters": {"ANOTHER_PARAM": "stuff"}}
+            "component": {"component_var": "something", "parameters": {"ANOTHER_PARAM": "stuff"}},
         }
     }
 
@@ -237,9 +248,92 @@ def test__get_variables_service_set_overrides():
             "PARAM": "something",
             "ANOTHER_PARAM": "stuff",
             "NAMESPACE": "test-project",
-            "SECRETS_PROJECT": SecretImporter.source_project
-        }
+            "SECRETS_PROJECT": SecretImporter.source_project,
+        },
     }
 
     runner = patched_runner(["test_env"], build_mock_loader(base_var_data, service_set_var_data))
-    assert runner._get_variables("service", "service/env", "component") == expected
+    assert runner._get_variables("service", "templates/service", "component") == expected
+
+
+def test__get_variables_multiple_envs():
+    base_var_data = {
+        "test_env": {
+            "global": {"global_var": "base_global1", "parameters": {"GLOBAL_PARAM": "things1"}},
+        },
+        "test_env2": {
+            "global": {"global_var": "base_global2"},
+            "service/component": {"component_var": "comp2"},
+        },
+        "test_env3": {
+            "global": {
+                "global_var": "base_global3",
+                "parameters": {"GLOBAL_PARAM": "things3", "ENV3_PARAM": "env3"},
+            },
+            "service/component": {"component_var": "comp3"},
+        },
+    }
+
+    service_set_var_data = {
+        "test_env": {"global": {"global_set_var": "set_global1"}},
+        "test_env2": {
+            "service/component": {
+                "component_var": "comp2-set",
+                "parameters": {"ENV2_PARAM": "env2"},
+            }
+        },
+    }
+
+    expected = {
+        "global_var": "base_global1",
+        "global_set_var": "set_global1",
+        "component_var": "comp2-set",
+        "parameters": {
+            "GLOBAL_PARAM": "things1",
+            "ENV3_PARAM": "env3",
+            "ENV2_PARAM": "env2",
+            "NAMESPACE": "test-project",
+            "SECRETS_PROJECT": SecretImporter.source_project,
+        },
+    }
+
+    runner = patched_runner(
+        ["test_env", "test_env2", "test_env3"],
+        build_mock_loader(base_var_data, service_set_var_data),
+    )
+    assert runner._get_variables("service", "templates/service", "component") == expected
+
+
+def test__get_variables_multiple_envs_legacy():
+    base_var_data = {
+        "test_env": {
+            "global": {"global_var": "base_global1", "parameters": {"GLOBAL_PARAM": "things1"}},
+        },
+        "test_env2": {
+            "global": {"global_var": "base_global2"},
+            "service/component": {"component_var": "comp2"},
+        },
+        "test_env3": {
+            "global": {
+                "global_var": "base_global3",
+                "parameters": {"GLOBAL_PARAM": "things3", "ENV3_PARAM": "env3"},
+            },
+            "service/component": {"component_var": "comp3"},
+        },
+    }
+
+    expected = {
+        "global_var": "base_global1",
+        "component_var": "comp2",
+        "parameters": {
+            "GLOBAL_PARAM": "things1",
+            "ENV3_PARAM": "env3",
+            "NAMESPACE": "test-project",
+            "SECRETS_PROJECT": SecretImporter.source_project,
+        },
+    }
+
+    runner = patched_runner(
+        ["test_env", "test_env2", "test_env3"], build_mock_loader(base_var_data), legacy=True
+    )
+    assert runner._get_variables("service", "templates/service", "component") == expected

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -1,0 +1,77 @@
+import pytest
+
+import ocdeployer
+
+@pytest.fixture
+def mock_files(monkeypatch):
+    def mock_get_cfg_files_in_dir(path):
+        if path == "env":
+            return ["env/test_env.yml", "env/other_env.yml"]
+        if path == "empty_env_dir":
+            return []
+
+    def mock_load_cfg_file(path):
+        if path == "env/test_env.yml":
+            return {
+                "service": {"enable_routes": False, "enable_db": False, "parameters": {"STUFF": "things"}}
+            }
+        if path == "env/other_env.yml":
+            return {
+                "another_service": {"somekey": "somevalue"}
+            }
+
+    monkeypatch.setattr(ocdeployer.utils, "get_cfg_files_in_dir", mock_get_cfg_files_in_dir)
+    monkeypatch.setattr(ocdeployer.utils, "load_cfg_file", mock_load_cfg_file)
+
+
+def test__load_vars_per_env(mock_files):
+    import ocdeployer.env
+    ech = ocdeployer.env.EnvConfigHandler(env_names=["test_env", "other_env"])
+
+    expected = {
+        'test_env': {
+            'service': {
+                "enable_routes": False, "enable_db": False, "parameters": {"STUFF": "things"}
+            }
+        },
+        'other_env': {
+            'another_service': {
+                'somekey': 'somevalue'
+            }
+        }
+    }
+
+    assert ech._load_vars_per_env("env") == expected
+
+
+def test__load_vars_per_env_ignore_other_env(mock_files):
+    import ocdeployer.env
+    ech = ocdeployer.env.EnvConfigHandler(env_names=["test_env"])
+
+    expected = {
+        'test_env': {
+            'service': {
+                "enable_routes": False, "enable_db": False, "parameters": {"STUFF": "things"}
+            }
+        }
+    }
+
+    assert ech._load_vars_per_env("env") == expected
+
+
+def test__load_vars_per_env_no_envs_specified(mock_files):
+    import ocdeployer.env
+    ech = ocdeployer.env.EnvConfigHandler(env_names=[])
+
+    expected = {}
+
+    assert ech._load_vars_per_env("env") == expected
+
+
+def test__load_vars_per_env_no_env_files_in_dir(mock_files):
+    import ocdeployer.env
+    ech = ocdeployer.env.EnvConfigHandler(env_names=['test_env'])
+
+    expected = {}
+
+    assert ech._load_vars_per_env("empty_env_dir") == expected

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -1,6 +1,7 @@
 import pytest
 
-import ocdeployer
+import ocdeployer.env
+
 
 @pytest.fixture
 def mock_files(monkeypatch):
@@ -13,20 +14,23 @@ def mock_files(monkeypatch):
     def mock_load_cfg_file(path):
         if path == "env/test_env.yml":
             return {
-                "service": {"enable_routes": False, "enable_db": False, "parameters": {"STUFF": "things"}}
+                "service": {
+                    "enable_routes": False, "enable_db": False, "parameters": {"STUFF": "things"}
+                }
             }
         if path == "env/other_env.yml":
             return {
                 "another_service": {"somekey": "somevalue"}
             }
 
-    monkeypatch.setattr(ocdeployer.utils, "get_cfg_files_in_dir", mock_get_cfg_files_in_dir)
-    monkeypatch.setattr(ocdeployer.utils, "load_cfg_file", mock_load_cfg_file)
+    # To understand why we're patching at 'ocdeployer.env'...
+    # Read: https://docs.python.org/3/library/unittest.mock.html#where-to-patch
+    monkeypatch.setattr("ocdeployer.env.get_cfg_files_in_dir", mock_get_cfg_files_in_dir)
+    monkeypatch.setattr("ocdeployer.env.load_cfg_file", mock_load_cfg_file)
 
 
 def test__load_vars_per_env(mock_files):
-    import ocdeployer.env
-    ech = ocdeployer.env.EnvConfigHandler(env_names=["test_env", "other_env"])
+    handler = ocdeployer.env.EnvConfigHandler(env_names=["test_env", "other_env"])
 
     expected = {
         'test_env': {
@@ -41,12 +45,11 @@ def test__load_vars_per_env(mock_files):
         }
     }
 
-    assert ech._load_vars_per_env("env") == expected
+    assert handler._load_vars_per_env("env") == expected
 
 
 def test__load_vars_per_env_ignore_other_env(mock_files):
-    import ocdeployer.env
-    ech = ocdeployer.env.EnvConfigHandler(env_names=["test_env"])
+    handler = ocdeployer.env.EnvConfigHandler(env_names=["test_env"])
 
     expected = {
         'test_env': {
@@ -56,22 +59,20 @@ def test__load_vars_per_env_ignore_other_env(mock_files):
         }
     }
 
-    assert ech._load_vars_per_env("env") == expected
+    assert handler._load_vars_per_env("env") == expected
 
 
 def test__load_vars_per_env_no_envs_specified(mock_files):
-    import ocdeployer.env
-    ech = ocdeployer.env.EnvConfigHandler(env_names=[])
+    handler = ocdeployer.env.EnvConfigHandler(env_names=[])
 
     expected = {}
 
-    assert ech._load_vars_per_env("env") == expected
+    assert handler._load_vars_per_env("env") == expected
 
 
 def test__load_vars_per_env_no_env_files_in_dir(mock_files):
-    import ocdeployer.env
-    ech = ocdeployer.env.EnvConfigHandler(env_names=['test_env'])
+    handler = ocdeployer.env.EnvConfigHandler(env_names=['test_env'])
 
     expected = {}
 
-    assert ech._load_vars_per_env("empty_env_dir") == expected
+    assert handler._load_vars_per_env("empty_env_dir") == expected

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -6,22 +6,22 @@ import ocdeployer.env
 @pytest.fixture
 def mock_files(monkeypatch):
     def mock_get_cfg_files_in_dir(path):
-        if path == "env":
+        if "env" in path:
             return ["env/test_env.yml", "env/other_env.yml"]
-        if path == "empty_env_dir":
+        if "empty" in path:
             return []
 
     def mock_load_cfg_file(path):
         if path == "env/test_env.yml":
             return {
                 "service": {
-                    "enable_routes": False, "enable_db": False, "parameters": {"STUFF": "things"}
+                    "enable_routes": False,
+                    "enable_db": False,
+                    "parameters": {"STUFF": "things"},
                 }
             }
         if path == "env/other_env.yml":
-            return {
-                "another_service": {"somekey": "somevalue"}
-            }
+            return {"another_service": {"somekey": "somevalue"}}
 
     # To understand why we're patching at 'ocdeployer.env'...
     # Read: https://docs.python.org/3/library/unittest.mock.html#where-to-patch
@@ -33,33 +33,33 @@ def test__load_vars_per_env(mock_files):
     handler = ocdeployer.env.EnvConfigHandler(env_names=["test_env", "other_env"])
 
     expected = {
-        'test_env': {
-            'service': {
-                "enable_routes": False, "enable_db": False, "parameters": {"STUFF": "things"}
+        "test_env": {
+            "service": {
+                "enable_routes": False,
+                "enable_db": False,
+                "parameters": {"STUFF": "things"},
             }
         },
-        'other_env': {
-            'another_service': {
-                'somekey': 'somevalue'
-            }
-        }
+        "other_env": {"another_service": {"somekey": "somevalue"}},
     }
 
-    assert handler._load_vars_per_env("env") == expected
+    assert handler._load_vars_per_env() == expected
 
 
 def test__load_vars_per_env_ignore_other_env(mock_files):
     handler = ocdeployer.env.EnvConfigHandler(env_names=["test_env"])
 
     expected = {
-        'test_env': {
-            'service': {
-                "enable_routes": False, "enable_db": False, "parameters": {"STUFF": "things"}
+        "test_env": {
+            "service": {
+                "enable_routes": False,
+                "enable_db": False,
+                "parameters": {"STUFF": "things"},
             }
         }
     }
 
-    assert handler._load_vars_per_env("env") == expected
+    assert handler._load_vars_per_env() == expected
 
 
 def test__load_vars_per_env_no_envs_specified(mock_files):
@@ -67,12 +67,12 @@ def test__load_vars_per_env_no_envs_specified(mock_files):
 
     expected = {}
 
-    assert handler._load_vars_per_env("env") == expected
+    assert handler._load_vars_per_env() == expected
 
 
 def test__load_vars_per_env_no_env_files_in_dir(mock_files):
-    handler = ocdeployer.env.EnvConfigHandler(env_names=['test_env'])
+    handler = ocdeployer.env.EnvConfigHandler(env_names=["test_env"], env_dir_name="empty_dir")
 
     expected = {}
 
-    assert handler._load_vars_per_env("empty_env_dir") == expected
+    assert handler._load_vars_per_env() == expected


### PR DESCRIPTION
This will allow env files to also be defined inside the service-set directory.

Instead of having a single root-level env file with data like this:
```
global:
  global_var: something

service_set:
  var1: true
  var2: false

service_set/component:
  var2: true
```

You can now place an env file in `service_set/env` that looks like this:
```
global:
  var1: true
  var2: false

component:
  var2: true
```
and the root level env file could then look like this:
```
global:
  global_var: something
```

The service-set level file will be merged into the root-level file. So, if you have 'env/ci.yml' and 'templates/service_set/env/ci.yml' -- running ocdeployer with `-e ci` will cause the values of the service set env file to take precedence over the values of the root level env file ... but ONLY in the context of that service set.

Writing a single root level env file in the "traditional way" will still be supported.

However, the `-e` flag is changing. You will no longer need to enter a specific path here, just the name of the env (which corresponds to the basename of the env file). So `-e ci` will look for the presence of a `ci.yml/ci.yaml/ci.json` in the `env` dir and also check for the presence of it in each service set's env dir at deploy time.