### PR TITLE
Ability to specific custom script inside service set, remove custom env dir for new-style env loading

### DIFF
--- a/ocdeployer/env.py
+++ b/ocdeployer/env.py
@@ -210,6 +210,7 @@ class LegacyEnvConfigHandler(EnvConfigHandler):
     """
     Allows use of --env in "legacy mode", i.e. pass in specific env files instead of env names.
     """
+
     def __init__(self, env_files):
         self.env_files = env_files
         self._last_service_set = None

--- a/setup.py
+++ b/setup.py
@@ -33,5 +33,5 @@ setup(
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
     ],
-    python_requires=">=3.4",
+    python_requires=">=3.5",
 )


### PR DESCRIPTION
* Removed --env-dir-name, for new-style env loading the dir will always be "env"
* Added ability to specify custom scripts inside the service set, by placing the script at `template_dir/service_set_dir/custom/deploy.py`