### PR TITLE
Remove "cache" command

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,6 @@ Options:
   -h, --help  Show this message and exit.
 
 Commands:
-  cache        Used for updating or deleting local template cache
   deploy       Deploy to project
   list-routes  List routes currently in the project
   list-sets    List service sets available in template dir
@@ -134,25 +133,6 @@ Use `list-routes` to simply print the URLs for active routes in a project
 #### List-sets command
 
 Use `list-sets` to simply print the names of service sets that are available for deployment in your templates directory.
-
-#### Cache command
-
-The `cache` command provides a shortcut method to store a git repository of templates in your local application cache folder. If the cache has been initialized and the folder exists, `ocdeployer` uses this folder as its default location instead of the current working directory.
-
-The implementation uses the `appdirs` cache folder, therefore...
-
-* the default templates dir becomes:
-  - Linux: `/home/<username>/.cache/ocdeployer/templates`
-  - Mac: `/Users/USERNAME/Library/Application Support/ocdeployer/templates`
-* the default scripts dir becomes:
-  - Linux: `/home/<username>/.cache/ocdeployer/custom`
-  - Mac: `/Users/USERNAME/Library/Application Support/ocdeployer/custom`
-* the default secrets dir becomes:
-  - Linux: `/home/<username>/.cache/ocdeployer/secrets`
-  - Mac: `/Users/USERNAME/Library/Application Support/ocdeployer/secrets`
-
-
-Note these defaults are only used IF the cache directory for `ocdeployer` is present.
 
 ---
 ## Template Configuration

--- a/ocdeployer/env.py
+++ b/ocdeployer/env.py
@@ -2,15 +2,12 @@ import copy
 import os
 from collections import defaultdict
 
-import appdirs
-import pathlib
 from cached_property import cached_property
 
-from .utils import get_cfg_files_in_dir, load_cfg_file, object_merge
+from .utils import get_cfg_files_in_dir, get_dir, load_cfg_file, object_merge
 
 
 GLOBAL = "global"
-APPDIRS_PATH = pathlib.Path(appdirs.user_cache_dir(appname="ocdeployer"))
 
 
 def convert_to_regular_dict(data):
@@ -25,9 +22,8 @@ def nested_dict():
 
 class EnvConfigHandler:
     def __init__(self, env_names, env_dir_name="env"):
-        path = APPDIRS_PATH / env_dir_name
-        path = path if path.exists() else pathlib.Path(pathlib.os.getcwd()) / env_dir_name
-        self.base_env_path = os.path.abspath(path)
+        env_path = os.path.join(os.getcwd(), env_dir_name)
+        self.base_env_path = get_dir(env_path, env_path, "environment")  # ensures path is valid dir
         self.env_dir_name = env_dir_name
         self.env_names = env_names
         self._last_service_set = None
@@ -134,6 +130,7 @@ class EnvConfigHandler:
         "global" is a reserved service set name and component name
         """
         path = os.path.join(service_set_dir, self.env_dir_name)
+        path = get_dir(path, path, "environment")  # ensures path is valid dir
 
         vars_per_env = self._load_vars_per_env(path)
 

--- a/ocdeployer/templates.py
+++ b/ocdeployer/templates.py
@@ -202,7 +202,7 @@ class Template(object):
         )
 
         if skipped_params:
-            log.warning(
+            log.info(
                 "Skipped parameters defined in config but not present in template: %s",
                 ", ".join(skipped_params),
             )

--- a/ocdeployer/utils.py
+++ b/ocdeployer/utils.py
@@ -109,6 +109,22 @@ def load_cfg_file(path):
     return content
 
 
+def get_dir(value, default_value, dir_type, optional=False):
+    path = value or default_value
+    required_dir_does_not_exist = not optional and not os.path.exists(path)
+    required_dir_is_not_a_dir = not optional and not os.path.isdir(path)
+    path_exists_but_not_a_dir = os.path.exists(path) and not os.path.isdir(path)
+    if required_dir_does_not_exist:
+        log.error("%s directory missing: %s", dir_type, path)
+        sys.exit(1)
+    if required_dir_is_not_a_dir or path_exists_but_not_a_dir:
+        log.error("%s directory invalid: %s", dir_type, path)
+        sys.exit(1)
+    path = os.path.abspath(path)
+    log.info("Found %s path: %s", dir_type, path)
+    return path
+
+
 def all_sets(template_dir):
     try:
         cfg_data = load_cfg_file(f"{template_dir}/_cfg.yaml")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,30 @@
+import pytest
+
+
+def _is_test_path(path):
+    return "envTEST" in path
+
+
+def _patch_exists(path):
+    if _is_test_path(path):
+        print(f"Overriding os.path.exists for path={path}")
+        return True
+
+
+def _patch_isdir(path):
+    if _is_test_path(path):
+        print(f"Overriding os.path.isdir for path={path}")
+        return True
+
+
+def _patch_isfile(path):
+    if _is_test_path(path):
+        print(f"Overriding os.path.isfile for path={path}")
+        return True
+
+
+@pytest.fixture
+def patch_os_path(monkeypatch):
+    monkeypatch.setattr("os.path.exists", _patch_exists)
+    monkeypatch.setattr("os.path.isdir", _patch_isdir)
+    monkeypatch.setattr("os.path.isfile", _patch_isfile)


### PR DESCRIPTION
The "cache" command no longer has any key uses as far as I am aware of. Removing it from the code to clean things up. Removing use of pathlib/appdirs in order to use os.path consistently across the project.

Also adding `--env-file` option back in for backward-compatibility with 3.x

Also adding further validations/logging related to the directories used for templates/deploy scripts/environment files/secrets

Fixing tests to be compatible with the above changes
