### PR TITLE
Add support for linking secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,9 @@ The best way to explain how template configuration works is to describe the proc
     # secret it won't be imported again.
     secrets:
     - "mysecret"
+    # You can also specify which service accounts a secret should be linked to
+    - name: "othersecret"
+      link: ["builder"]
 
     # (optional) custom_deploy_logic
     #
@@ -331,12 +334,14 @@ def post_deploy(**kwargs):
 
 ### Secrets
 
-By default, `ocdeployer` will attempt to import secrets from the project `secrets` in OpenShift as well as by looking for secrets in the `./secrets` local directory. You can also use `--secrets-src-project` to copy secrets into your project from a different project in OpenShift, or use `--secrets-local-dir` to load secrets from Openshift config files in a directory.
+By default, `ocdeployer` will attempt to import secrets from the project `secrets` in OpenShift as well as by looking for secrets in the `./secrets` local directory. You can also use `--secrets-src-project` to copy secrets into your project from a different project in OpenShift, or use `--secrets-local-dir` to load secrets from OpenShift config files in a different directory.
 
-Any .yaml/.json files you place in the `secrets-local-dir` will be parsed and secrets will be pulled out of them and imported.
-The files can contain a single secret OR a list of resources
+If you set `--secrets-src-project` to be the same as the destination namespace, this effectively causes ocdeployer to simply validate that the secret is present in that namespace.
 
-An example secret .yaml configuration:
+Any `.yaml`/`.json` files you place in the `secrets-local-dir` will be parsed and secrets will be pulled out of them and imported.
+The files can contain a single secret (`kind: Secret`) OR a list of resources (`kind: List`)
+
+An example secret `.yaml` file:
 ```
 apiVersion: v1
 data:
@@ -347,6 +352,24 @@ metadata:
     name: my_secret
 type: kubernetes.io/ssh-auth
 ```
+
+Secrets can be specified in `_cfg.yml` in two ways:
+
+Listing just the name:
+```
+secrets:
+- "name of secret"
+```
+
+(`ocdeployer>=v4.2.0`) Listing the name as well as the service accounts the secret should be linked to using `oc secrets link`:
+```
+secrets:
+- name: "name of secret"
+  link: ["account1", "account2"]
+```
+
+Note that any links existing for a secret will not be removed at deploy time -- `ocdeployer` will only add new links.
+
 
 #### How do I export secrets from a project to use later with `--secrets-local-dir`?
 

--- a/ocdeployer/deploy.py
+++ b/ocdeployer/deploy.py
@@ -159,6 +159,9 @@ def _parse_secrets(config):
                     raise ValueError("'link' in 'secrets' is not a list of strings")
 
             secrets.append({"name": name, "link": link})
+        else:
+            raise ValueError("secret data syntax for _cfg.yml is incorrect")
+
 
     return secrets
 

--- a/ocdeployer/deploy.py
+++ b/ocdeployer/deploy.py
@@ -162,7 +162,6 @@ def _parse_secrets(config):
         else:
             raise ValueError("secret data syntax for _cfg.yml is incorrect")
 
-
     return secrets
 
 

--- a/ocdeployer/deploy.py
+++ b/ocdeployer/deploy.py
@@ -138,10 +138,36 @@ def deploy_dry_run(
 DEFAULT_DEPLOY_METHODS = (None, deploy_components, None)
 
 
+def _parse_secrets(config):
+    secrets = []
+
+    for secret in config.get("secrets", []):
+        if isinstance(secret, str):
+            secrets.append({"name": secret, "link": []})
+        elif isinstance(secret, dict):
+            name = secret.get("name")
+            link = secret.get("link", [])
+
+            if not name:
+                raise ValueError("Secret listed in _cfg.yml is missing 'name'")
+            if link:
+                try:
+                    iter(link)
+                except TypeError:
+                    raise ValueError("'link' in 'secrets' is not a list of strings")
+                if not all([isinstance(item, str) for item in link]):
+                    raise ValueError("'link' in 'secrets' is not a list of strings")
+
+            secrets.append({"name": name, "link": link})
+
+    return secrets
+
+
 def _handle_secrets_and_imgs(config):
     # Import the specified secrets
-    for secret_name in config.get("secrets", []):
-        SecretImporter.do_import(secret_name)
+    secrets = _parse_secrets(config)
+    for secret in secrets:
+        SecretImporter.do_import(**secret)
 
     # Import the specified images
     for img_name, img_src in config.get("images", {}).items():

--- a/ocdeployer/secrets.py
+++ b/ocdeployer/secrets.py
@@ -91,15 +91,19 @@ class SecretImporter(object):
             cls.imported_secret_names.append(name)
 
     @classmethod
-    def do_import(cls, name, verify=False):
+    def do_import(cls, name, link=None, verify=False):
         """
-        Import secret to openshift project
+        Import secret to openshift project and optionally link to service accounts.
 
         If local_dir is defined, this tries to import all secrets in that dir first. If the
         secret we want is still not imported, we try to import from source_project instead
         """
         if name not in cls.imported_secret_names:
             cls._import(name)
+
+        if link:
+            for sa in link:
+                oc("secrets", "link", sa, name, "--for=pull,mount")
 
         if verify:
             exists = oc("get", "secret", name, _exit_on_err=False)


### PR DESCRIPTION
Secrets can now be specified in _cfg.yml in two ways:

Listing just the name (traditional syntax):
```
secrets:
- "name of secret"
```

Listing the name as well as the service accounts the secret should be linked to using `oc secrets link` (new for ocdeployer>=v4.2.0):

```
secrets:
- name: "name of secret"
  link: ["account1", "account2"]
```

Note that any links existing for a secret will not be removed at deploy time -- ocdeployer will only add new links.