### PR TITLE
Support for conditionally importing secrets and images

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,6 +365,12 @@ images:
 * `istag` -- the desired ImageStreamTag
 * `from` -- the image's external "from" URI
 * `envs` -- lists envs this image should be imported for. The image will only be imported when ocdeployer is run with `--env` matching the envs given. If no envs are given, it is assumed it should be loaded in all envs.
+```
+images:
+- istag: "cp-kafka:sometag"
+  from: "confluentinc/cp-kafka"
+  envs: ["qa", "prod"]
+```
 
 ### Secrets
 

--- a/ocdeployer/env.py
+++ b/ocdeployer/env.py
@@ -38,7 +38,7 @@ class EnvConfigHandler:
         self.base_env_path = get_dir(env_path, env_path, "environment")  # ensures path is valid dir
         self.env_dir_name = env_dir_name
         self.env_names = _dedupe_preserve_order(env_names)
-        if len(env_names) != self.env_names:
+        if len(env_names) != len(self.env_names):
             log.warning("Duplicate env names provided: %s", env_names)
         self._last_service_set = None
         self._last_merged_vars = None

--- a/ocdeployer/env.py
+++ b/ocdeployer/env.py
@@ -22,12 +22,22 @@ def nested_dict():
     return defaultdict(nested_dict)
 
 
+def _dedupe_preserve_order(seq):
+    """De-dupe a list, but preserve order of elements.
+
+    https://www.peterbe.com/plog/uniqifiers-benchmark
+    """
+    seen = set()
+    seen_add = seen.add
+    return [x for x in seq if not (x in seen or seen_add(x))]
+
+
 class EnvConfigHandler:
     def __init__(self, env_names, env_dir_name="env"):
         env_path = os.path.join(os.getcwd(), env_dir_name)
         self.base_env_path = get_dir(env_path, env_path, "environment")  # ensures path is valid dir
         self.env_dir_name = env_dir_name
-        self.env_names = set(env_names)
+        self.env_names = _dedupe_preserve_order(env_names)
         if len(env_names) != self.env_names:
             log.warning("Duplicate env names provided: %s", env_names)
         self._last_service_set = None
@@ -220,7 +230,7 @@ class LegacyEnvConfigHandler(EnvConfigHandler):
         self.env_files = env_files
         self._last_service_set = None
         _env_names = [self._get_env_name(fp) for fp in self.env_files]
-        self.env_names = set(_env_names)
+        self.env_names = _dedupe_preserve_order(_env_names)
         if len(_env_names) != len(self.env_names):
             log.warning("Duplicate env names provided: %s", _env_names)
 

--- a/ocdeployer/images.py
+++ b/ocdeployer/images.py
@@ -1,0 +1,77 @@
+import logging
+
+from sh import ErrorReturnCode
+
+from .utils import oc, validate_list_of_strs
+
+
+log = logging.getLogger("ocdeployer.images")
+
+
+def _parse_config(config):
+    images = []
+
+    for img in config.get("images", []):
+        if not isinstance(img, dict):
+            raise ValueError("entries in 'images' must be of type 'dict'")
+        if len(img.keys()) >= 2 and all([k in img for k in ["istag", "from"]]):
+            # This entry is using new-style image definition, e.g.
+            #   images:
+            #   - istag: "image_name"
+            #   - from: "quay.io/some/image_name:image_tag"
+            #   - envs: ["stage", "prod"]
+            istag = img["istag"]
+            _from = img["from"]
+            envs = img.get("envs", [])
+        elif len(img.keys()) == 1 and all([k not in img for k in ["istag", "from", "envs"]]):
+            # This entry is using old-style image definition, e.g.
+            #   images:
+            #   - "image_name:image_tag": "quay.io/some/image_name:image_tag"
+            istag, _from = list(img.items())[0]
+            envs = []
+        else:
+            raise ValueError("Unknown syntax for 'images' section of config")
+
+        if not isinstance(istag, str) or not isinstance(_from, str):
+            raise ValueError("'istag' and 'from' must be a of type 'string'")
+        validate_list_of_strs("envs", "images", envs)
+
+        images.append({"istag": istag, "from": _from, "envs": envs})
+
+    return images
+
+
+def _retag_image(istag, image_from):
+    istag_split = istag.split(":")
+    image_name = istag_split[0]
+    if len(istag_split) < 2:
+        image_tag = "latest"
+    else:
+        image_tag = istag_split[1:]
+
+    oc(
+        "tag", "--scheduled=True", "--source=docker", image_from, f"{image_name}:{image_tag}",
+    )
+
+
+def import_images(config, env_names):
+    """Import the specified images listed in a _cfg.yml"""
+    images = _parse_config(config)
+    for img_data in images:
+        istag = img_data["istag"]
+        image_from = img_data["from"]
+        if not img_data["envs"] or any([e in env_names for e in img_data["envs"]]):
+            try:
+                oc(
+                    "import-image",
+                    istag,
+                    "--from={}".format(image_from),
+                    "--confirm",
+                    "--scheduled=True",
+                    _reraise=True,
+                )
+            except ErrorReturnCode as err:
+                if "use the 'tag' command if you want to change the source" in str(err.stderr):
+                    _retag_image(istag, image_from)
+        else:
+            log.info("Skipping import of image '%s', not enabled for this env", img_data["istag"])

--- a/ocdeployer/utils.py
+++ b/ocdeployer/utils.py
@@ -50,8 +50,9 @@ def validate_list_of_strs(item_name, section, l):
         iter(l)
     except TypeError:
         bad = True
-    if not all([isinstance(i, str) for i in l]):
-        bad = True
+    else:
+        if not all([isinstance(i, str) for i in l]):
+            bad = True
 
     if bad:
         raise ValueError(f"'{item_name}' in '{section}' is not a list of strings")

--- a/ocdeployer/utils.py
+++ b/ocdeployer/utils.py
@@ -43,6 +43,20 @@ SHORTCUTS = {
 }
 
 
+def validate_list_of_strs(item_name, section, l):
+    bad = False
+
+    try:
+        iter(l)
+    except TypeError:
+        bad = True
+    if not all([isinstance(i, str) for i in l]):
+        bad = True
+
+    if bad:
+        raise ValueError(f"'{item_name}' in '{section}' is not a list of strings")
+
+
 def object_merge(old, new):
     """
     Recursively merge two data structures

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,3 +1,4 @@
 -r requirements.txt
 pytest
 flake8
+pytest-mock

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -362,17 +362,9 @@ def test__get_variables_multiple_envs_legacy(patch_os_path):
 
 
 def test__get_variables_multiple_envs_precedence(patch_os_path):
-    base_var_data = {
-        "test_env1": {
-            "service/component": {"parameters": {"PARAM": "things1"}},
-        },
-    }
+    base_var_data = {"test_env1": {"service/component": {"parameters": {"PARAM": "things1"}}}}
 
-    service_set_var_data = {
-        "test_env2": {
-            "component": {"parameters": {"PARAM": "things2"}},
-        },
-    }
+    service_set_var_data = {"test_env2": {"component": {"parameters": {"PARAM": "things2"}}}}
 
     expected = {
         "parameters": {
@@ -383,24 +375,15 @@ def test__get_variables_multiple_envs_precedence(patch_os_path):
     }
 
     runner = patched_runner(
-        ["test_env1", "test_env2"],
-        build_mock_loader(base_var_data, service_set_var_data),
+        ["test_env1", "test_env2"], build_mock_loader(base_var_data, service_set_var_data),
     )
     assert runner._get_variables("service", "templates/service", "component") == expected
 
 
 def test__get_variables_multiple_envs_precedence_reversed(patch_os_path):
-    base_var_data = {
-        "test_env1": {
-            "service/component": {"parameters": {"PARAM": "things1"}},
-        },
-    }
+    base_var_data = {"test_env1": {"service/component": {"parameters": {"PARAM": "things1"}}}}
 
-    service_set_var_data = {
-        "test_env2": {
-            "component": {"parameters": {"PARAM": "things2"}},
-        },
-    }
+    service_set_var_data = {"test_env2": {"component": {"parameters": {"PARAM": "things2"}}}}
 
     expected = {
         "parameters": {
@@ -411,7 +394,6 @@ def test__get_variables_multiple_envs_precedence_reversed(patch_os_path):
     }
 
     runner = patched_runner(
-        ["test_env2", "test_env1"],
-        build_mock_loader(base_var_data, service_set_var_data),
+        ["test_env2", "test_env1"], build_mock_loader(base_var_data, service_set_var_data),
     )
     assert runner._get_variables("service", "templates/service", "component") == expected

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -1,0 +1,106 @@
+import pytest
+
+from ocdeployer.images import import_images
+
+
+@pytest.fixture
+def mock_oc(mocker):
+    _mock_oc = mocker.patch("ocdeployer.images.oc")
+    yield _mock_oc
+
+
+def _check_oc_calls(mocker, mock_oc):
+    assert mock_oc.call_count == 2
+    calls = [
+        mocker.call(
+            "import-image",
+            "image1:tag",
+            "--from=docker.url/image1:sometag",
+            "--confirm",
+            "--scheduled=True",
+            _reraise=True,
+        ),
+        mocker.call(
+            "import-image",
+            "image2:tag",
+            "--from=docker.url/image2:sometag",
+            "--confirm",
+            "--scheduled=True",
+            _reraise=True,
+        ),
+    ]
+    mock_oc.assert_has_calls(calls)
+
+
+def test_old_style_syntax(mocker, mock_oc):
+    config_content = {
+        "images": [
+            {"image1:tag": "docker.url/image1:sometag"},
+            {"image2:tag": "docker.url/image2:sometag"},
+        ]
+    }
+
+    import_images(config_content, [])
+
+    _check_oc_calls(mocker, mock_oc)
+
+
+def test_new_style_syntax(mocker, mock_oc):
+    config_content = {
+        "images": [
+            {"istag": "image1:tag", "from": "docker.url/image1:sometag"},
+            {"istag": "image2:tag", "from": "docker.url/image2:sometag"},
+        ]
+    }
+
+    import_images(config_content, [])
+
+    _check_oc_calls(mocker, mock_oc)
+
+
+def test_mixed_style_syntax(mocker, mock_oc):
+    config_content = {
+        "images": [
+            {"image1:tag": "docker.url/image1:sometag"},
+            {"istag": "image2:tag", "from": "docker.url/image2:sometag"},
+        ]
+    }
+
+    import_images(config_content, [])
+
+    _check_oc_calls(mocker, mock_oc)
+
+
+def test_conditional_images(mocker, mock_oc):
+    config_content = {
+        "images": [
+            {"istag": "image1:tag", "from": "docker.url/image1:sometag", "envs": ["qa", "prod"]},
+            {"istag": "image2:tag", "from": "docker.url/image2:sometag"},
+        ]
+    }
+    import_images(config_content, ["prod"])
+
+    _check_oc_calls(mocker, mock_oc)
+
+
+def test_conditional_ignore_image(mocker, mock_oc):
+    config_content = {
+        "images": [
+            {"istag": "image1:tag", "from": "docker.url/image1:sometag", "envs": ["qa", "prod"]},
+            {"istag": "image2:tag", "from": "docker.url/image2:sometag"},
+        ]
+    }
+    import_images(config_content, ["foo"])
+
+    assert mock_oc.call_count == 1
+    calls = [
+        mocker.call(
+            "import-image",
+            "image2:tag",
+            "--from=docker.url/image2:sometag",
+            "--confirm",
+            "--scheduled=True",
+            _reraise=True,
+        )
+    ]
+    mock_oc.assert_has_calls(calls)

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -32,7 +32,7 @@ def _check_oc_calls(mocker, mock_oc):
     mock_oc.assert_has_calls(calls)
 
 
-def test_old_style_syntax(mocker, mock_oc):
+def test_images_old_style_syntax(mocker, mock_oc):
     config_content = {
         "images": [
             {"image1:tag": "docker.url/image1:sometag"},
@@ -45,7 +45,7 @@ def test_old_style_syntax(mocker, mock_oc):
     _check_oc_calls(mocker, mock_oc)
 
 
-def test_new_style_syntax(mocker, mock_oc):
+def test_images_new_style_syntax(mocker, mock_oc):
     config_content = {
         "images": [
             {"istag": "image1:tag", "from": "docker.url/image1:sometag"},
@@ -58,7 +58,7 @@ def test_new_style_syntax(mocker, mock_oc):
     _check_oc_calls(mocker, mock_oc)
 
 
-def test_mixed_style_syntax(mocker, mock_oc):
+def test_images_mixed_style_syntax(mocker, mock_oc):
     config_content = {
         "images": [
             {"image1:tag": "docker.url/image1:sometag"},
@@ -71,7 +71,7 @@ def test_mixed_style_syntax(mocker, mock_oc):
     _check_oc_calls(mocker, mock_oc)
 
 
-def test_conditional_images(mocker, mock_oc):
+def test_images_conditional_images(mocker, mock_oc):
     config_content = {
         "images": [
             {"istag": "image1:tag", "from": "docker.url/image1:sometag", "envs": ["qa", "prod"]},
@@ -83,7 +83,7 @@ def test_conditional_images(mocker, mock_oc):
     _check_oc_calls(mocker, mock_oc)
 
 
-def test_conditional_ignore_image(mocker, mock_oc):
+def test_images_conditional_ignore_image(mocker, mock_oc):
     config_content = {
         "images": [
             {"istag": "image1:tag", "from": "docker.url/image1:sometag", "envs": ["qa", "prod"]},

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -32,7 +32,7 @@ def _check_oc_calls(mocker, mock_oc):
     mock_oc.assert_has_calls(calls)
 
 
-def test_images_old_style_syntax(mocker, mock_oc):
+def test_images_short_style_syntax(mocker, mock_oc):
     config_content = {
         "images": [
             {"image1:tag": "docker.url/image1:sometag"},
@@ -45,12 +45,25 @@ def test_images_old_style_syntax(mocker, mock_oc):
     _check_oc_calls(mocker, mock_oc)
 
 
-def test_images_new_style_syntax(mocker, mock_oc):
+def test_images_long_style_syntax(mocker, mock_oc):
     config_content = {
         "images": [
             {"istag": "image1:tag", "from": "docker.url/image1:sometag"},
             {"istag": "image2:tag", "from": "docker.url/image2:sometag"},
         ]
+    }
+
+    import_images(config_content, [])
+
+    _check_oc_calls(mocker, mock_oc)
+
+
+def test_images_old_style_syntax(mocker, mock_oc):
+    config_content = {
+        "images": {
+            "image1:tag": "docker.url/image1:sometag",
+            "image2:tag": "docker.url/image2:sometag",
+        }
     }
 
     import_images(config_content, [])


### PR DESCRIPTION
This adds support for specifying secrets and images in `_cfg.yml` like this:

```
secrets:
  name: "blah"
  envs: ["qa", "prod"]

images:
  istag: "blah:latest"
  from: "somerepo/blah:latest"
  envs: ["qa", "prod"]
```

These means these secrets/images will only be imported if the environment selected was 'qa' or 'prod'. If no `envs` are given, the item is imported in all environments. The old-style syntax of defining secrets and images will continue to be supported -- and will be the equivalent of specifying no `envs`.