### PR TITLE
Support for per-environment _cfg

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -68,8 +68,8 @@ The project structure will be as follows:
     images:
       # Images our configs rely on. We will run 'oc import-image' on these.
       # The key is the ImageStream name. The value is the docker image to pull.
-      nginx: "nginx"
-      postgresql: "postgresql"
+    - nginx: "nginx"
+    - postgresql: "postgresql"
 
     secrets:
     # Names of secrets these templates rely on that we need to import
@@ -93,8 +93,8 @@ The project structure will be as follows:
     images:
       # Images our configs rely on. We will run 'oc import-image' on these.
       # The key is the ImageStream name. The value is the docker image to pull.
-      origin-custom-docker-builder: "openshift/origin-custom-docker-builder"
-      mysql-57-centos7: "centos/mysql-57-centos7"
+    - origin-custom-docker-builder: "openshift/origin-custom-docker-builder"
+    - mysql-57-centos7: "centos/mysql-57-centos7"
 
     # Indicates we are making use of a custom pre-deploy/deploy/post-deploy script
     custom_deploy_logic: True

--- a/ocdeployer/config.py
+++ b/ocdeployer/config.py
@@ -1,0 +1,54 @@
+from .secrets import parse_config as parse_secrets_config
+from .images import parse_config as parse_images_config
+from .utils import object_merge
+
+
+def merge_list_of_dicts(old, new, key):
+    """
+    Merge a list of dictionary items based on a specific key.
+
+    Dictionaries inside the list with a matching key get merged together.
+
+    Assumes that a value for the given key is unique and appears only once.
+
+    Example:
+    list1 = [{"name": "one", "data": "stuff"}, {"name": "two", "data": "stuff2"}]
+    list2 = [{"name": "one", "data": "newstuff"}]
+
+    merge_list_of_dicts(list1, list2) returns:
+    [{"name": "one", "data": "newstuff"}, {"name": "two", "data": "stuff2"}]
+    """
+    for old_item in old:
+        matching_val = old_item[key]
+        for new_item in new:
+            if new_item[key] == matching_val:
+                object_merge(old_item, new_item)
+                break
+        else:
+            new.append(old_item)
+    return new
+
+
+def merge_cfgs(old, new):
+    """
+    Merges two ocdeployer _cfg definitions together.
+
+    This is similar to an object_merge but with special processing of the 'images' and 'secrets'
+    since these are lists of dictionaries
+
+    object_merge simply merges items from an old & new list together. Instead, if 2 dictionaries
+    are defining data for the name 'images' or 'secrets', we want to merge the data of those
+    dictionaries together.
+    """
+    old_images = parse_images_config(old)
+    new_images = parse_images_config(new)
+    old_secrets = parse_secrets_config(old)
+    new_secrets = parse_secrets_config(new)
+
+    # First do a standard object_merge, we'll then replace 'images' and 'secrets'
+    object_merge(old, new)
+    # Now merge the list of dictionaries together using their identifying key
+    new['images'] = merge_list_of_dicts(old_images, new_images, key="istag")
+    new['secrets'] = merge_list_of_dicts(old_secrets, new_secrets, key="name")
+
+    return new

--- a/ocdeployer/config.py
+++ b/ocdeployer/config.py
@@ -18,7 +18,7 @@ def merge_list_of_dicts(old, new, key):
     merge_list_of_dicts(list1, list2) returns:
     [{"name": "one", "data": "newstuff"}, {"name": "two", "data": "stuff2"}]
     """
-    for old_item in old:
+    for old_item in reversed(old):
         matching_val = old_item[key]
         for new_item in new:
             if new_item[key] == matching_val:
@@ -31,14 +31,14 @@ def merge_list_of_dicts(old, new, key):
 
 def merge_cfgs(old, new):
     """
-    Merges two ocdeployer _cfg definitions together.
+    Merges two _cfg definitions together.
 
     This is similar to an object_merge but with special processing of the 'images' and 'secrets'
     since these are lists of dictionaries
 
     object_merge simply merges items from an old & new list together. Instead, if 2 dictionaries
-    are defining data for the name 'images' or 'secrets', we want to merge the data of those
-    dictionaries together.
+    items in the lists are defining data for the same image or secret, we want to merge the data of
+    those dictionaries together.
     """
     old_images = parse_images_config(old)
     new_images = parse_images_config(new)
@@ -48,7 +48,7 @@ def merge_cfgs(old, new):
     # First do a standard object_merge, we'll then replace 'images' and 'secrets'
     object_merge(old, new)
     # Now merge the list of dictionaries together using their identifying key
-    new['images'] = merge_list_of_dicts(old_images, new_images, key="istag")
-    new['secrets'] = merge_list_of_dicts(old_secrets, new_secrets, key="name")
+    new["images"] = merge_list_of_dicts(old_images, new_images, key="istag")
+    new["secrets"] = merge_list_of_dicts(old_secrets, new_secrets, key="name")
 
     return new

--- a/ocdeployer/deploy.py
+++ b/ocdeployer/deploy.py
@@ -10,7 +10,7 @@ import yaml
 
 from .config import merge_cfgs
 from .images import import_images
-from .utils import load_cfg_file, object_merge, oc, wait_for_ready_threaded
+from .utils import load_cfg_file, oc, wait_for_ready_threaded
 from .secrets import import_secrets, SecretImporter
 from .templates import get_templates_in_dir
 
@@ -401,8 +401,7 @@ class DeployRunner(object):
         # Merge the values from the two _cfg definitions, with env settings taking precedence
         return merge_cfgs(base_cfg, base_env_cfg)
 
-    def _get_service_set_cfg(self, service_set):
-        dir_path = os.path.join(self.template_dir, service_set)
+    def _get_service_set_cfg(self, service_set, dir_path):
         cfg_path = os.path.join(dir_path, "_cfg.yml")
 
         if not os.path.isdir(dir_path) or not os.path.isfile(cfg_path):
@@ -421,7 +420,8 @@ class DeployRunner(object):
         log.info("Handling config for service set '%s'", service_set)
         processed_templates = {}
 
-        set_cfg = self._get_service_set_cfg(service_set)
+        dir_path = os.path.join(self.template_dir, service_set)
+        set_cfg = self._get_service_set_cfg(service_set, dir_path)
 
         if not self.ignore_requires:
             self._check_requires(set_cfg, service_set)

--- a/ocdeployer/deploy.py
+++ b/ocdeployer/deploy.py
@@ -9,7 +9,7 @@ import sys
 import yaml
 
 from .images import import_images
-from .utils import load_cfg_file, oc, wait_for_ready_threaded
+from .utils import load_cfg_file, object_merge, oc, wait_for_ready_threaded
 from .secrets import import_secrets, SecretImporter
 from .templates import get_templates_in_dir
 
@@ -274,12 +274,11 @@ class DeployRunner(object):
         self.env_config_handler = env_config_handler
 
     def _get_variables(self, service_set_name, service_set_dir, component):
+        variables = {}
         if self.env_config_handler:
             variables = self.env_config_handler.get_vars_for_component(
                 service_set_dir, service_set_name, component
             )
-        else:
-            variables = {}
 
         # ocdeployer adds the "NAMESPACE" and "SECRETS_PROJECT" parameter by default at deploy time
         if "parameters" not in variables:
@@ -290,9 +289,9 @@ class DeployRunner(object):
 
         return variables
 
-    def _get_variables_per_component(self, service_set_content, service_set_dir, service_set_name):
+    def _get_variables_per_component(self, set_cfg, service_set_dir, service_set_name):
         variables_per_component = {}
-        for _, stage_config in service_set_content.get("deploy_order", {}).items():
+        for _, stage_config in set_cfg.get("deploy_order", {}).items():
             variables_per_component.update(
                 {
                     component_name: self._get_variables(
@@ -303,8 +302,8 @@ class DeployRunner(object):
             )
         return variables_per_component
 
-    def _check_requires(self, service_set_content, service_set_name):
-        requires = service_set_content.get("requires", [])
+    def _check_requires(self, set_cfg, service_set_name):
+        requires = set_cfg.get("requires", [])
         for required_set in requires:
             if required_set not in self._deployed_service_sets:
                 raise ValueError(
@@ -387,34 +386,59 @@ class DeployRunner(object):
             dir_path,
         )
 
+    def _get_base_cfg(self):
+        cfg_path = os.path.join(self.template_dir, "_cfg.yml")
+        if not os.path.isdir(self.template_dir) or not os.path.isfile(cfg_path):
+            raise ValueError(f"Unable to find config at {cfg_path}")
+
+        # Load _cfg.yml from templates dir
+        base_cfg = load_cfg_file(cfg_path)
+        # Check if base env files have '_cfg' defined
+        base_env_cfg = {}
+        if self.env_config_handler:
+            base_env_cfg = self.env_config_handler.get_base_env_cfg()
+        # Merge the values from the two _cfg definitions, with env settings taking precedence
+        return object_merge(base_cfg, base_env_cfg)
+
+    def _get_service_set_cfg(self, service_set):
+        dir_path = os.path.join(self.template_dir, service_set)
+        cfg_path = os.path.join(dir_path, "_cfg.yml")
+
+        if not os.path.isdir(dir_path) or not os.path.isfile(cfg_path):
+            raise ValueError(f"Unable to find config for service set at {cfg_path}")
+
+        # Load _cfg.yml from service set
+        set_cfg = load_cfg_file(cfg_path)
+        # Check if service set env files have '_cfg' defined
+        set_env_cfg = {}
+        if self.env_config_handler:
+            set_env_cfg = self.env_config_handler.get_service_set_env_cfg(dir_path, service_set)
+        # Merge the values from the two _cfg definitions, with env settings taking precedence
+        return object_merge(set_cfg, set_env_cfg)
+
     def _deploy_service_set(self, service_set):
         log.info("Handling config for service set '%s'", service_set)
         processed_templates = {}
 
-        dir_path = os.path.join(self.template_dir, service_set)
-        cfg_path = os.path.join(dir_path, "_cfg.yml")
+        set_cfg = self._get_service_set_cfg(service_set)
 
-        if not os.path.isdir(dir_path):
-            raise ValueError("Unable to find directory for service set {}".format(service_set))
-
-        content = load_cfg_file(cfg_path)
         if not self.ignore_requires:
-            self._check_requires(content, service_set)
+            self._check_requires(set_cfg, service_set)
 
         if self.dry_run:
             log.info("Doing a DRY RUN of deployment")
             pre_deploy_func, deploy_func, post_deploy_func = None, deploy_dry_run, None
         else:
-            import_secrets(content, self.env_config_handler.env_names)
-            import_images(content, self.env_config_handler.env_names)
+            import_secrets(set_cfg, self.env_config_handler.env_names)
+            import_images(set_cfg, self.env_config_handler.env_names)
 
             pre_deploy_func, deploy_func, post_deploy_func = _get_deploy_methods(
-                content, service_set, dir_path, self.root_custom_dir
+                set_cfg, service_set, dir_path, self.root_custom_dir
             )
 
-        variables_per_component = self._get_variables_per_component(content, dir_path, service_set)
+        variables_per_component = self._get_variables_per_component(set_cfg, dir_path, service_set)
 
-        deploy_order = content.get("deploy_order", {})
+        deploy_order = set_cfg.get("deploy_order", {})
 
         if pre_deploy_func:
             log.info("Running pre_deploy() for service set '%s'", service_set)
@@ -438,7 +462,7 @@ class DeployRunner(object):
                 project_name=self.project_name,
                 template_dir=dir_path,
                 variables_per_component=variables_per_component,
-                timeout=int(content.get("post_deploy_timeout", 0)),
+                timeout=int(set_cfg.get("post_deploy_timeout", 0)),
             )
 
         self._deployed_service_sets.append(service_set)
@@ -459,12 +483,12 @@ class DeployRunner(object):
         """
         self._deployed_service_sets = []
 
-        content = load_cfg_file(os.path.join(self.template_dir, "_cfg.yml"))
-        deploy_order = content.get("deploy_order", {})
+        base_cfg = self._get_base_cfg()
+        deploy_order = base_cfg.get("deploy_order", {})
 
         if not self.dry_run:
-            import_secrets(content, self.env_config_handler.env_names)
-            import_images(content, self.env_config_handler.env_names)
+            import_secrets(base_cfg, self.env_config_handler.env_names)
+            import_images(base_cfg, self.env_config_handler.env_names)
 
         # Verify all service sets exist
         all_service_sets = []

--- a/ocdeployer/deploy.py
+++ b/ocdeployer/deploy.py
@@ -8,6 +8,7 @@ import os
 import sys
 import yaml
 
+from .config import merge_cfgs
 from .images import import_images
 from .utils import load_cfg_file, object_merge, oc, wait_for_ready_threaded
 from .secrets import import_secrets, SecretImporter
@@ -398,7 +399,7 @@ class DeployRunner(object):
         if self.env_config_handler:
             base_env_cfg = self.env_config_handler.get_base_env_cfg()
         # Merge the values from the two _cfg definitions, with env settings taking precedence
-        return object_merge(base_cfg, base_env_cfg)
+        return merge_cfgs(base_cfg, base_env_cfg)
 
     def _get_service_set_cfg(self, service_set):
         dir_path = os.path.join(self.template_dir, service_set)
@@ -414,7 +415,7 @@ class DeployRunner(object):
         if self.env_config_handler:
             set_env_cfg = self.env_config_handler.get_service_set_env_cfg(dir_path, service_set)
         # Merge the values from the two _cfg definitions, with env settings taking precedence
-        return object_merge(set_cfg, set_env_cfg)
+        return merge_cfgs(set_cfg, set_env_cfg)
 
     def _deploy_service_set(self, service_set):
         log.info("Handling config for service set '%s'", service_set)

--- a/ocdeployer/env.py
+++ b/ocdeployer/env.py
@@ -154,10 +154,19 @@ class EnvConfigHandler:
 
         return convert_to_regular_dict(data)
 
-    def _merge_env_cfgs(self, vars_per_env):
+    def _merge_env_cfgs(self, vars_per_env, service_set=None):
         merged_cfg = {}
         for env in self.env_names:
-            cfg = vars_per_env.get(env, {}).get(CFG, {})
+            cfg = {}
+            if service_set:
+                # Look for a _cfg key under [env][service_set]['_cfg']
+                for key, data in vars_per_env.get(env, {}).items():
+                    if service_set and key == service_set:
+                        cfg = data.get(CFG, {})
+                        break
+            else:
+                # Look for a _cfg key under [env]['_cfg']
+                cfg = vars_per_env.get(env, {}).get(CFG, {})
             merge_cfgs(cfg, merged_cfg)
         return merged_cfg
 
@@ -178,7 +187,7 @@ class EnvConfigHandler:
         what order the envs were listed in.
         """
         return self._merge_env_cfgs(
-            self._get_service_set_vars(service_set_dir, service_set)
+            self._get_service_set_vars(service_set_dir, service_set), service_set=service_set
         )
 
     def _merge_service_set_vars(self, service_set_dir, service_set):

--- a/ocdeployer/env.py
+++ b/ocdeployer/env.py
@@ -10,6 +10,7 @@ from .utils import get_cfg_files_in_dir, get_dir, load_cfg_file, object_merge
 
 log = logging.getLogger("ocdeployer.env")
 GLOBAL = "global"
+CFG = "_cfg"
 
 
 def convert_to_regular_dict(data):

--- a/ocdeployer/images.py
+++ b/ocdeployer/images.py
@@ -61,7 +61,7 @@ def _parse_old_style(images):
     return parsed_images
 
 
-def _parse_config(config):
+def parse_config(config):
     if "images" in config:
         if isinstance(config["images"], dict):
             return _parse_old_style(config["images"])
@@ -114,7 +114,7 @@ class ImageImporter:
 def import_images(config, env_names):
     """Import the specified images listed in a _cfg.yml"""
 
-    images = _parse_config(config)
+    images = parse_config(config)
     for img_data in images:
         istag = img_data["istag"]
         image_from = img_data["from"]

--- a/ocdeployer/secrets.py
+++ b/ocdeployer/secrets.py
@@ -59,7 +59,7 @@ def import_secret_from_project(project, secret_name):
     )
 
 
-def _parse_config(config):
+def parse_config(config):
     secrets = []
 
     for secret in config.get("secrets", []):
@@ -136,7 +136,7 @@ class SecretImporter(object):
 
 def import_secrets(config, env_names):
     """Import the specified secrets listed in a _cfg.yml"""
-    secrets = _parse_config(config)
+    secrets = parse_config(config)
     for secret in secrets:
         if not secret["envs"] or any([e in env_names for e in secret["envs"]]):
             SecretImporter.do_import(**secret)

--- a/ocdeployer/utils.py
+++ b/ocdeployer/utils.py
@@ -58,14 +58,14 @@ def validate_list_of_strs(item_name, section, l):
         raise ValueError(f"'{item_name}' in '{section}' is not a list of strings")
 
 
-def object_merge(old, new):
+def object_merge(old, new, merge_lists=True):
     """
     Recursively merge two data structures
 
     Thanks rsnyman :)
     https://github.com/rochacbruno/dynaconf/commit/458ffa6012f1de62fc4f68077f382ab420b43cfc#diff-c1b434836019ae32dc57d00dd1ae2eb9R15
     """
-    if isinstance(old, list) and isinstance(new, list):
+    if isinstance(old, list) and isinstance(new, list) and merge_lists:
         for item in old[::-1]:
             new.insert(0, item)
     if isinstance(old, dict) and isinstance(new, dict):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@ import pytest
 
 
 def _is_test_path(path):
-    return "envTEST" in path
+    return "TEST" in path
 
 
 def _patch_exists(path):

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -15,7 +15,9 @@ def patched_runner(env_values, mock_load_vars_per_env, legacy=False):
     else:
         handler = EnvConfigHandler(env_names=env_values, env_dir_name="envTEST")
 
-    runner = DeployRunner("templatesTEST", "test-project", handler, None, ["service"], None, None, [])
+    runner = DeployRunner(
+        "templatesTEST", "test-project", handler, None, ["service"], None, None, []
+    )
     runner.base_env_path = "base/envTEST"
 
     if handler:
@@ -37,7 +39,7 @@ def build_mock_env_loader(base_env_data, service_set_env_data={}):
         return {}
 
     return mock_load_vars_per_env
-            
+
 
 @pytest.fixture
 def patch_load_cfg(monkeypatch):
@@ -49,6 +51,7 @@ def patch_load_cfg(monkeypatch):
     * "templatesTEST/_cfg.yml"
     * "templatesTEST/service/_cfg.yml"
     """
+
     def _func(base_cfg_data, service_cfg_data):
         def _patched_load_cfg_file(path):
             if path.endswith(os.path.join("templatesTEST", "service", "_cfg.yml")):
@@ -58,7 +61,7 @@ def patch_load_cfg(monkeypatch):
             else:
                 raise Exception("Unknown path passed to load_cfg_file")
 
-        monkeypatch.setattr('ocdeployer.deploy.load_cfg_file', _patched_load_cfg_file)
+        monkeypatch.setattr("ocdeployer.deploy.load_cfg_file", _patched_load_cfg_file)
 
     yield _func
 
@@ -67,83 +70,138 @@ def test_cfg_no_env_given(patch_os_path, patch_load_cfg):
     runner = patched_runner(None, None)
     base_cfg_data = {
         "secrets": ["secret1"],
-        "images": ["image1"]
+        "images": [{"image1:latest": "somerepo/image1:latest"}],
     }
-    set_cfg_data = {
-        "secrets": ["secret2"],
-        "images": ["image2"]
-    }
+    set_cfg_data = {"secrets": ["secret2"], "images": [{"image2:latest": "somerepo/image2:latest"}]}
     patch_load_cfg(base_cfg_data, set_cfg_data)
-    assert runner._get_base_cfg() == base_cfg_data
-    assert runner._get_service_set_cfg("service") == set_cfg_data
+
+    # no env file defined that has '_cfg' key, there should be no changes to the cfg
+    assert runner._get_base_cfg() == {
+        "secrets": [{"name": "secret1", "envs": [], "link": []}],
+        "images": [{"istag": "image1:latest", "from": "somerepo/image1:latest", "envs": []}],
+    }
+
+    assert runner._get_service_set_cfg("service", "templatesTEST/service") == {
+        "secrets": [{"name": "secret2", "envs": [], "link": []}],
+        "images": [{"istag": "image2:latest", "from": "somerepo/image2:latest", "envs": []}],
+    }
 
 
 def test_cfg_no_env_cfg(patch_os_path, patch_load_cfg):
     base_cfg_data = {
         "secrets": ["secret1"],
-        "images": ["image1"]
+        "images": [{"image1:latest": "somerepo/image1:latest"}],
     }
-    set_cfg_data = {
-        "secrets": ["secret2"],
-        "images": ["image2"]
-    }
-    mock_var_data = {
-        "test_env": {
-            "service": {
-                "some_set": "stuff"
-            }
-        }
-    }
-    mock_set_var_data = {
-        "test_env": {
-            "component": {
-                "some_var": "stuff"
-            }
-        }
-    }
+    set_cfg_data = {"secrets": ["secret2"], "images": [{"image2:latest": "somerepo/image2:latest"}]}
+    mock_var_data = {"test_env": {"service": {"some_set": "stuff"}}}
+    mock_set_var_data = {"test_env": {"component": {"some_var": "stuff"}}}
 
     patch_load_cfg(base_cfg_data, set_cfg_data)
     runner = patched_runner(["test_env"], build_mock_env_loader(mock_var_data, mock_set_var_data))
-    assert runner._get_base_cfg() == base_cfg_data
-    assert runner._get_service_set_cfg("service") == set_cfg_data
+
+    # env file had no _cfg, so we should not see any changes to the cfg
+    assert runner._get_base_cfg() == {
+        "secrets": [{"name": "secret1", "envs": [], "link": []}],
+        "images": [{"istag": "image1:latest", "from": "somerepo/image1:latest", "envs": []}],
+    }
+
+    assert runner._get_service_set_cfg("service", "templatesTEST/service") == {
+        "secrets": [{"name": "secret2", "envs": [], "link": []}],
+        "images": [{"istag": "image2:latest", "from": "somerepo/image2:latest", "envs": []}],
+    }
 
 
 def test_cfg_base_env_cfg(patch_os_path, patch_load_cfg):
     base_cfg_data = {
         "secrets": ["secret1"],
-        "images": ["image1"]
+        "images": [{"image1:latest": "somerepo/image1:latest"}],
     }
-    set_cfg_data = {
-        "secrets": ["secret2"],
-        "images": ["image2"]
-    }
+    set_cfg_data = {"secrets": ["secret2"], "images": [{"image2:latest": "somerepo/image2:latest"}]}
     mock_var_data = {
         "test_env": {
             "_cfg": {
-                "secrets": ["overridden-secret1"],
-                "extrastuff": "things"
+                "secrets": ["additional-secret1"],
+                "images": [{"image1:latest": "overridden-image"}],
+                "extrastuff": "things",
             },
-            "service": {
-                "some_set": "stuff"
-            }
+            "service": {"some_set": "stuff"},
+        }
+    }
+    mock_set_var_data = {"test_env": {"component": {"some_var": "stuff"}}}
+
+    patch_load_cfg(base_cfg_data, set_cfg_data)
+    runner = patched_runner(["test_env"], build_mock_env_loader(mock_var_data, mock_set_var_data))
+
+    # base env file had a _cfg, we should see base env file config merged into base config
+    assert runner._get_base_cfg() == {
+        "secrets": [
+            {"name": "additional-secret1", "envs": [], "link": []},
+            {"name": "secret1", "envs": [], "link": []},
+        ],
+        "extrastuff": "things",
+        "images": [{"istag": "image1:latest", "from": "overridden-image", "envs": []}],
+    }
+
+    # service set env file had no _cfg, so it should be unchanged
+    assert runner._get_service_set_cfg("service", "templatesTEST/service") == {
+        "secrets": [{"name": "secret2", "envs": [], "link": []}],
+        "images": [{"istag": "image2:latest", "from": "somerepo/image2:latest", "envs": []}],
+    }
+
+
+def test_cfg_set_env_cfg(patch_os_path, patch_load_cfg):
+    base_cfg_data = {
+        "secrets": ["secret1"],
+        "images": [{"image1:latest": "somerepo/image1:latest"}],
+    }
+    set_cfg_data = {"secrets": ["secret2"], "images": [{"image2:latest": "somerepo/image2:latest"}]}
+    mock_var_data = {
+        "test_env": {
+            "_cfg": {
+                "secrets": ["additional-secret1"],
+                "images": [{"image1:latest": "overridden-image"}],
+                "extrastuff": "things",
+            },
+            "service": {"some_set": "stuff"},
         }
     }
     mock_set_var_data = {
         "test_env": {
-            "component": {
-                "some_var": "stuff"
-            }
+            "_cfg": {
+                "secrets": ["some-secret-for-set-only"],
+                "images": [
+                    {"image3": "somerepo/image3:latest"},
+                    {"image2:latest": "overridden-image-2"},
+                ],
+            },
+            "component": {"some_var": "stuff"},
         }
     }
 
     patch_load_cfg(base_cfg_data, set_cfg_data)
     runner = patched_runner(["test_env"], build_mock_env_loader(mock_var_data, mock_set_var_data))
+
+    # base env file had a _cfg, we should see base env file config merged into base config
     assert runner._get_base_cfg() == {
-        "secrets": ["overriden-secret1"],
+        "secrets": [
+            {"name": "additional-secret1", "envs": [], "link": []},
+            {"name": "secret1", "envs": [], "link": []},
+        ],
         "extrastuff": "things",
-        "images": ["image1"]
+        "images": [{"istag": "image1:latest", "from": "overridden-image", "envs": []}],
     }
-    assert runner._get_service_set_cfg("service") == set_cfg_data
+
+    # set env file had a _cfg, we should see set env file config merged into set config
+    assert runner._get_service_set_cfg("service", "templatesTEST/service") == {
+        "secrets": [
+            {"name": "some-secret-for-set-only", "envs": [], "link": []},
+            {"name": "secret2", "envs": [], "link": []},
+        ],
+        "images": [
+            {"istag": "image2:latest", "from": "overridden-image-2", "envs": []},
+            {"istag": "image3:latest", "from": "somerepo/image3:latest", "envs": []},
+        ],
+    }
 
 
 def test__no_env_given():
@@ -324,7 +382,9 @@ def test__get_variables_base_and_service_set(patch_os_path):
         },
     }
 
-    runner = patched_runner(["test_env"], build_mock_env_loader(base_var_data, service_set_var_data))
+    runner = patched_runner(
+        ["test_env"], build_mock_env_loader(base_var_data, service_set_var_data)
+    )
     assert runner._get_variables("service", "templates/service", "component") == expected
 
 
@@ -349,7 +409,9 @@ def test__get_variables_service_set_only(patch_os_path):
         },
     }
 
-    runner = patched_runner(["test_env"], build_mock_env_loader(base_var_data, service_set_var_data))
+    runner = patched_runner(
+        ["test_env"], build_mock_env_loader(base_var_data, service_set_var_data)
+    )
     assert runner._get_variables("service", "templates/service", "component") == expected
 
 
@@ -382,7 +444,9 @@ def test__get_variables_service_set_overrides(patch_os_path):
         },
     }
 
-    runner = patched_runner(["test_env"], build_mock_env_loader(base_var_data, service_set_var_data))
+    runner = patched_runner(
+        ["test_env"], build_mock_env_loader(base_var_data, service_set_var_data)
+    )
     assert runner._get_variables("service", "templates/service", "component") == expected
 
 


### PR DESCRIPTION
This will allow a section with key `_cfg` to be placed in an env file. It can be used to override or add to the values set in the base `_cfg.yml` or the service set's `_cfg.yml`.

This will allow config options for a deployment to be tweaked based on the env file selected for deploy.

The main requirement driving this change is the desire to import specific images in specific environments. For example, in the `prod` environment I want to import `quay.io/org/myapp:prod` but in the `qa` environment I want to import `quay.io/org/myapp:qa`

* A `_cfg` defined in a base env file will override values set in the base `_cfg`.
* A `_cfg` defined in a service set's env file will override values set in the `_cfg` for that service set.
* A `ImageImporter` will be created, similar to the `SecretImporter` -- to ensure that we don't repeatedly re-import the same istags if we're deploying multiple service sets.