### PR TITLE
Workaround for boolean parameters in env files

### DIFF
--- a/ocdeployer/templates.py
+++ b/ocdeployer/templates.py
@@ -160,6 +160,17 @@ class Template(object):
         with open(self.path, "r") as f:
             return self._jinja_safe(f.read())
 
+    @staticmethod
+    def _format_oc_parameter(param_value):
+        """
+        Hack around yaml dump behaviour for different datatypes
+        Examples:
+            yaml.dump(True) -> 'true\n...\n'
+            yaml.dump('True') -> "'True'\n"
+            yaml.dump('123') -> "'123'\n"
+        """
+        return yaml.dump(param_value).replace("\n...\n", "").strip()
+
     def _process_via_oc(self, content, parameters=None, label=None):
         """
         Run 'oc process' on the template and update content with the processed output
@@ -176,10 +187,9 @@ class Template(object):
         if not parameters:
             parameters = {}
 
-        # Create set of param strings to pass into 'oc process'
         params_and_vals = {}
         for param_name, param_value in parameters.items():
-            params_and_vals[param_name] = "{}={}".format(param_name, param_value)
+            params_and_vals[param_name] = "{}={}".format(param_name, self._format_oc_parameter(param_value))
 
         extra_args = []
         # Only insert the parameter if it was defined in the template

--- a/ocdeployer/templates.py
+++ b/ocdeployer/templates.py
@@ -189,7 +189,9 @@ class Template(object):
 
         params_and_vals = {}
         for param_name, param_value in parameters.items():
-            params_and_vals[param_name] = "{}={}".format(param_name, self._format_oc_parameter(param_value))
+            params_and_vals[param_name] = "{}={}".format(
+                param_name, self._format_oc_parameter(param_value)
+            )
 
         extra_args = []
         # Only insert the parameter if it was defined in the template

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-PyYAML
+PyYAML==5.3
 sh
 prompter
 click

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -1,0 +1,19 @@
+import pytest
+
+from ocdeployer.templates import Template
+
+
+@pytest.mark.parametrize(
+    'value,expected',
+    (
+        (True, 'true'),
+        ('True', "'True'"),
+        ('true', "'true'"),
+        ('123', "'123'"),
+        (123, '123'),
+        ('123:123:123', '123:123:123'),
+        ('some text', 'some text')
+    )
+)
+def test_template_oc_param_format(value, expected):
+    assert Template._format_oc_parameter(value) == expected


### PR DESCRIPTION
In current version boolean type parameters not correctly interpolates to templates.
This connected with types casting during yaml deserealization and following casts this objects to strings.

Example env file
```
global:
  env: dev
  parameters:
    BOOLEAN: true
```


Example template
```
...
  some_boolean_required_parameter: ${{BOOLEAN}}

parameters:
  - name: BOOLEAN
    required: true
```

Result will be like
```
...
  some_boolean_required_parameter: 'True'
```
which is not expected boolean...

This changes fixes that behaviour.
But I'm not sure that all edge cases was covered, yaml.dump is not a super consistent in its behaviour.