### PR TITLE
Apply parameter re-formatting only for ints and bools

### DIFF
--- a/ocdeployer/templates.py
+++ b/ocdeployer/templates.py
@@ -163,13 +163,11 @@ class Template(object):
     @staticmethod
     def _format_oc_parameter(param_value):
         """
-        Hack around yaml dump behaviour for different datatypes
-        Examples:
-            yaml.dump(True) -> 'true\n...\n'
-            yaml.dump('True') -> "'True'\n"
-            yaml.dump('123') -> "'123'\n"
+        Ensures that non-string parameter values are inserted into template properly
         """
-        return yaml.dump(param_value).replace("\n...\n", "").strip()
+        if isinstance(param_value, bool) or isinstance(param_value, int): 
+            return json.dumps(param_value)
+        return param_value
 
     def _process_via_oc(self, content, parameters=None, label=None):
         """

--- a/ocdeployer/templates.py
+++ b/ocdeployer/templates.py
@@ -165,7 +165,7 @@ class Template(object):
         """
         Ensures that non-string parameter values are inserted into template properly
         """
-        if isinstance(param_value, bool) or isinstance(param_value, int): 
+        if isinstance(param_value, bool) or isinstance(param_value, int):
             return json.dumps(param_value)
         return param_value
 

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -7,9 +7,9 @@ from ocdeployer.templates import Template
     'value,expected',
     (
         (True, 'true'),
-        ('True', "'True'"),
-        ('true', "'true'"),
-        ('123', "'123'"),
+        ('True', 'True'),
+        ('true', 'true'),
+        ('123', '123'),
         (123, '123'),
         ('123:123:123', '123:123:123'),
         ('some text', 'some text')


### PR DESCRIPTION
@lobziik #36 intoduced an issue...

A template parameter defined like this in the env file:
```
component:
  parameters:
    SOME_PARAM: '1'
```

And referenced in a template like this:
```
something: ${SOME_PARAM}
```

Ended up looking like this in the template once processed:
```
something: '''1'''
```

and OpenShift threw this error:
```
INFO:ocdeployer.utils: |stderr| Error from server: quantities must match the regular expression '^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$'
```

This PR should still accomplish what you were trying to do (convert bools and ints into strings)