### PR TITLE
Support for processing jinja only, plus some black formatting

### DIFF
--- a/ocdeployer/__main__.py
+++ b/ocdeployer/__main__.py
@@ -246,6 +246,13 @@ def _parse_args(template_dir, env_values, env_files, all_services, sets, pick, d
     default=None,
     help="Save processed templates to specific output directory (default: print to stdout)",
 )
+@click.option(
+    "-j",
+    "--jinja-only",
+    default=False,
+    is_flag=True,
+    help="Only provide the output of processing jinja, excludes 'oc process'",
+)
 @click.argument("dst_project")
 def deploy_dry_run(
     dst_project,
@@ -259,6 +266,7 @@ def deploy_dry_run(
     skip,
     output,
     to_dir,
+    jinja_only,
 ):
     template_dir, env_config_handler, specific_components, sets_selected, _ = _parse_args(
         template_dir, env_values, env_files, all_services, sets, pick, dst_project
@@ -278,7 +286,7 @@ def deploy_dry_run(
         label=None,
         skip=skip.split(",") if skip else None,
         dry_run=True,
-        dry_run_opts={"output": output, "to_dir": to_dir},
+        dry_run_opts={"output": output, "to_dir": to_dir, "jinja_only": jinja_only},
     ).run()
 
 
@@ -286,14 +294,10 @@ def deploy_dry_run(
 @common_options
 @click.option("--no-confirm", "-f", is_flag=True, help="Do not prompt for confirmation")
 @click.option(
-    "--secrets-local-dir",
-    default=None,
-    help="Import secrets from local files in a directory",
+    "--secrets-local-dir", default=None, help="Import secrets from local files in a directory",
 )
 @click.option(
-    "--secrets-src-project",
-    default=None,
-    help="Openshift project to import secrets from",
+    "--secrets-src-project", default=None, help="Openshift project to import secrets from",
 )
 @click.option(
     "--ignore-requires",

--- a/ocdeployer/secrets.py
+++ b/ocdeployer/secrets.py
@@ -150,6 +150,5 @@ def import_secrets(config, env_names):
             SecretImporter.handle(**secret)
         else:
             log.info(
-                "Skipping check/import of secret '%s', not enabled for this env",
-                secret["name"]
+                "Skipping check/import of secret '%s', not enabled for this env", secret["name"]
             )

--- a/ocdeployer/templates.py
+++ b/ocdeployer/templates.py
@@ -143,6 +143,7 @@ class Template(object):
         self.path = path
         self.file_name, self.file_extension = os.path.splitext(self.path)
         self.processed_content = {}
+        self.processed_jinja_content = {}
 
     @staticmethod
     def _jinja_safe(data):
@@ -246,8 +247,13 @@ class Template(object):
         rendered_txt = template.render(**variables)
         if not rendered_txt.strip():
             log.info("Template '%s' is empty after jinja2 processing", self.file_name)
-            return None
-        return self._load_content(rendered_txt)
+            self.processed_jinja_content = {}
+        else:
+            self.processed_jinja_content = self._load_content(rendered_txt)
+        return self.processed_jinja_content
+
+    def process_jinja(self, variables):
+        return self._process_via_jinja2(variables)
 
     def process(self, variables, resources_scale_factor=1.0, label=None):
         # Run the template through jinja processing first

--- a/ocdeployer/utils.py
+++ b/ocdeployer/utils.py
@@ -163,15 +163,11 @@ def all_sets(template_dir):
 
 
 def _only_immutable_errors(err_lines):
-    return all(
-        "field is immutable after creation" in line.lower() for line in err_lines
-    )
+    return all("field is immutable after creation" in line.lower() for line in err_lines)
 
 
 def _conflicts_found(err_lines):
-    return any(
-        "error from server (conflict)" in line.lower() for line in err_lines
-    )
+    return any("error from server (conflict)" in line.lower() for line in err_lines)
 
 
 def _get_logging_args(args, kwargs):
@@ -628,11 +624,11 @@ def cancel_builds(bc_name):
     # Check if there's any lingering builds
     builds = get_json("build", label=f"openshift.io/build-config.name={bc_name}")
     lingering_builds = []
-    for build in builds.get('items', []):
+    for build in builds.get("items", []):
         # delete these builds rather than cancelling them, since jenkins pipeline builds
         # can remain stuck in certain states if OpenShift Sync plugin is broken
-        status = build.get('status') or {}
-        phase = status.get('phase', "").lower()
+        status = build.get("status") or {}
+        phase = status.get("phase", "").lower()
         if phase in ["new", "pending", "running"]:
             build_name = build["metadata"]["name"]
             lingering_builds.append(build_name)


### PR DESCRIPTION
You can now run `ocdeployer process` with `--jinja-only/-j` which will only process jinja2 and output a plain vanilla OpenShift template -- it will not run 'oc process' on the template.