### PR TITLE
Process command now outputs imagestream configs

### DIFF
--- a/ocdeployer/deploy.py
+++ b/ocdeployer/deploy.py
@@ -502,7 +502,9 @@ class DeployRunner(object):
             is_configs = copy.deepcopy(self._base_is_configs)
             new_is_configs = get_is_configs(set_cfg, self.env_config_handler.env_names)
             for istag, is_config in new_is_configs.items():
-                # If an istag is imported by the base _cfg, it will not be re-imported by this _cfg
+                # If an istag is imported by the base _cfg, due to the way ImageImporter works,
+                # it will not be re-imported again. So don't overwrite that istag in our
+                # processed output either.
                 if istag not in is_configs:
                     is_configs[istag] = is_config
 

--- a/ocdeployer/deploy.py
+++ b/ocdeployer/deploy.py
@@ -1,6 +1,7 @@
 """
 Handles deploy logic for components
 """
+import copy
 import importlib
 import json
 import logging
@@ -9,10 +10,10 @@ import sys
 import yaml
 
 from .config import merge_cfgs
-from .images import import_images
+from .images import get_is_configs, import_images
 from .utils import cancel_builds, load_cfg_file, oc, wait_for_ready_threaded
 from .secrets import import_secrets, SecretImporter
-from .templates import get_templates_in_dir
+from .templates import Template, get_templates_in_dir
 
 
 log = logging.getLogger(__name__)
@@ -203,7 +204,7 @@ def _load_module(path, service_set):
     return module
 
 
-def _get_custom_methods(service_set, service_set_dir, root_custom_dir):
+def _get_custom_deploy_methods(service_set, service_set_dir, root_custom_dir):
     """
     Look for custom deploy module and import its methods.
     """
@@ -253,7 +254,7 @@ def _get_custom_methods(service_set, service_set_dir, root_custom_dir):
 
 def _get_deploy_methods(config, service_set_name, service_set_dir, root_custom_dir):
     if config.get("custom_deploy_logic", False):
-        pre_deploy_method, deploy_method, post_deploy_method = _get_custom_methods(
+        pre_deploy_method, deploy_method, post_deploy_method = _get_custom_deploy_methods(
             service_set_name, service_set_dir, root_custom_dir
         )
     else:
@@ -280,7 +281,13 @@ def generate_dry_run_content(all_processed_templates, output="yaml", to_dir=None
 
     for service_set, processed_templates in all_processed_templates.items():
         for template_name, template_obj in processed_templates.items():
-            content = getattr(template_obj, content_attr_name)
+            # Check if the template_obj is an actual template... the "_imagestreams" component
+            # added during dry run is just a plain dict
+            if isinstance(template_obj, Template):
+                content = getattr(template_obj, content_attr_name)
+            else:
+                content = template_obj
+
             if not content:
                 log.warning("Template '%s' had no processed content", template_name)
             else:
@@ -332,6 +339,7 @@ class DeployRunner(object):
         self.dry_run = dry_run
         self.dry_run_opts = dry_run_opts or {}
         self.env_config_handler = env_config_handler
+        self._base_is_configs = {}
 
     def _get_variables(self, service_set_name, service_set_dir, component):
         variables = {}
@@ -490,6 +498,21 @@ class DeployRunner(object):
             jinja_only = self.dry_run_opts.get("jinja_only")
             deploy_dry_run_func = deploy_dry_run_jinja_only if jinja_only else deploy_dry_run
             pre_deploy_func, deploy_func, post_deploy_func = None, deploy_dry_run_func, None
+
+            is_configs = copy.deepcopy(self._base_is_configs)
+            new_is_configs = get_is_configs(set_cfg, self.env_config_handler.env_names)
+            for istag, is_config in new_is_configs.items():
+                # If an istag is imported by the base _cfg, it will not be re-imported by this _cfg
+                if istag not in is_configs:
+                    is_configs[istag] = is_config
+
+            if is_configs:
+                processed_templates["_imagestreams"] = {
+                    "apiVersion": "v1",
+                    "kind": "List",
+                    "items": [config for _, config in is_configs.items()],
+                }
+
         else:
             import_secrets(set_cfg, self.env_config_handler.env_names)
             import_images(set_cfg, self.env_config_handler.env_names)
@@ -548,6 +571,7 @@ class DeployRunner(object):
         base_cfg = self._get_base_cfg()
         deploy_order = base_cfg.get("deploy_order", {})
 
+        self._base_is_configs = get_is_configs(base_cfg, self.env_config_handler.env_names)
         if not self.dry_run:
             import_secrets(base_cfg, self.env_config_handler.env_names)
             import_images(base_cfg, self.env_config_handler.env_names)

--- a/ocdeployer/images.py
+++ b/ocdeployer/images.py
@@ -133,12 +133,15 @@ class ImageImporter:
     def do_import(cls, istag, image_from, scheduled, **kwargs):
         if istag in cls.imported_istags:
             log.warning("istag '%s' already imported, skipping repeat import...", istag)
+            return
 
         scheduled = "True" if scheduled else "False"
         if get_json("istag", istag):
             cls._retag_image(istag, image_from, scheduled)
         else:
             cls._import_image(istag, image_from, scheduled)
+
+        cls.imported_istags.append(istag)
 
 
 def _get_args(config, env_names):

--- a/ocdeployer/utils.py
+++ b/ocdeployer/utils.py
@@ -637,3 +637,16 @@ def cancel_builds(bc_name):
         log.warning("Found lingering builds for bc/%s which will be deleted", bc_name)
         for build_name in lingering_builds:
             oc("delete", "build", build_name)
+
+
+def traverse_keys(d, keys, default=None):
+    """
+    Allows you to look up a 'path' of keys in nested dicts without knowing whether each key exists
+    """
+    key = keys.pop(0)
+    item = d.get(key, default)
+    if len(keys) == 0:
+        return item
+    if not item:
+        return default
+    return traverse_keys(item, keys, default)

--- a/tests/test_images.py
+++ b/tests/test_images.py
@@ -1,6 +1,6 @@
 import pytest
 
-from ocdeployer.images import import_images
+from ocdeployer.images import ImageImporter, import_images
 
 
 @pytest.fixture
@@ -40,7 +40,7 @@ def test_images_short_style_syntax(mocker, mock_oc):
             {"image2:tag": "docker.url/image2:sometag"},
         ]
     }
-
+    ImageImporter.imported_istags = []
     import_images(config_content, [])
 
     _check_oc_calls(mocker, mock_oc)
@@ -54,6 +54,7 @@ def test_images_long_style_syntax(mocker, mock_oc):
         ]
     }
 
+    ImageImporter.imported_istags = []
     import_images(config_content, [])
 
     _check_oc_calls(mocker, mock_oc)
@@ -67,6 +68,7 @@ def test_images_old_style_syntax(mocker, mock_oc):
         }
     }
 
+    ImageImporter.imported_istags = []
     import_images(config_content, [])
 
     _check_oc_calls(mocker, mock_oc)
@@ -80,6 +82,7 @@ def test_images_mixed_style_syntax(mocker, mock_oc):
         ]
     }
 
+    ImageImporter.imported_istags = []
     import_images(config_content, [])
 
     _check_oc_calls(mocker, mock_oc)
@@ -92,6 +95,8 @@ def test_images_conditional_images(mocker, mock_oc):
             {"istag": "image2:tag", "from": "docker.url/image2:sometag"},
         ]
     }
+
+    ImageImporter.imported_istags = []
     import_images(config_content, ["prod"])
 
     _check_oc_calls(mocker, mock_oc)
@@ -104,6 +109,8 @@ def test_images_conditional_ignore_image(mocker, mock_oc):
             {"istag": "image2:tag", "from": "docker.url/image2:sometag"},
         ]
     }
+
+    ImageImporter.imported_istags = []
     import_images(config_content, ["foo"])
 
     assert mock_oc.call_count == 1

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -4,16 +4,16 @@ from ocdeployer.templates import Template
 
 
 @pytest.mark.parametrize(
-    'value,expected',
+    "value,expected",
     (
-        (True, 'true'),
-        ('True', 'True'),
-        ('true', 'true'),
-        ('123', '123'),
-        (123, '123'),
-        ('123:123:123', '123:123:123'),
-        ('some text', 'some text')
-    )
+        (True, "true"),
+        ("True", "True"),
+        ("true", "true"),
+        ("123", "123"),
+        (123, "123"),
+        ("123:123:123", "123:123:123"),
+        ("some text", "some text"),
+    ),
 )
 def test_template_oc_param_format(value, expected):
     assert Template._format_oc_parameter(value) == expected


### PR DESCRIPTION
If image streams are declared for import under a `_cfg.yml`, running `ocdeployer process` now inserts an `_imagestreams.yaml` amongst the processed output of the service set -- this file shows the list of image stream configurations we would expect to exist in the namespace after `oc import-image` is run.

This is useful to see exactly what external images are configured for import within each service set.

Also includes 2 smaller changes:
* `ImageImporter.do_import` will properly skip re-import of already-imported images
* Added 'traverse_keys' utility function to utils.py