### PR TITLE
Determine which builds are linked and only trigger the first one

### DIFF
--- a/ocdeployer/deploy.py
+++ b/ocdeployer/deploy.py
@@ -11,7 +11,7 @@ import yaml
 
 from .config import merge_cfgs
 from .images import get_is_configs, import_images
-from .utils import cancel_builds, get_json, load_cfg_file, oc, wait_for_ready_threaded
+from .utils import load_cfg_file, oc, trigger_builds, wait_for_ready_threaded
 from .secrets import import_secrets, SecretImporter
 from .templates import Template, get_templates_in_dir
 
@@ -87,16 +87,9 @@ def deploy_components(
             )
 
         # Re-trigger any builds for deployed build configs
-        bcs = template.get_processed_names_for_restype("bc")
-        for name in bcs:
-            log.info("Triggering builds for '%s'", name)
-            # Cancel any new/pending builds
-            cancel_builds(name)
-            oc("start-build", "bc/{}".format(name))
-            json_data = get_json("bc", name)
-            last_version = json_data["status"]["lastVersion"]
-            build = "{}-{}".format(name, last_version)
-            resources_to_wait_for.append(("build", build))
+        bcs = template.get_processed_items_for_restype("bc")
+        if bcs:
+            resources_to_wait_for.extend(trigger_builds(bcs))
 
     # Wait on all resources that have been marked as 'resources to wait for'
     if wait:

--- a/ocdeployer/templates.py
+++ b/ocdeployer/templates.py
@@ -280,6 +280,19 @@ class Template(object):
     def dump_processed_json(self):
         return json.dumps(self.processed_content)
 
+    def get_processed_items_for_restype(self, restype):
+        """
+        Return list of objects of type 'restype' in the processed template
+
+        Note at the moment this only searches the 1st level of objects (for example,
+        it will not return the name of a pod embedded within a deployment config)
+        """
+        restype = parse_restype(restype)
+
+        return [
+            obj for obj in self.processed_content.get("items", []) if obj["kind"].lower() == restype
+        ]
+
     def get_processed_names_for_restype(self, restype):
         """
         Return list of names for all objects of type 'restype' in the processed template
@@ -287,12 +300,4 @@ class Template(object):
         Note at the moment this only searches the 1st level of objects (for example,
         it will not return the name of a pod embedded within a deployment config)
         """
-        restype = parse_restype(restype)
-
-        names = []
-
-        for obj in self.processed_content.get("items", []):
-            if obj["kind"].lower() == restype:
-                names.append(obj["metadata"]["name"])
-
-        return names
+        return [obj["metadata"]["name"] for obj in self.get_processed_items_for_restype(restype)]

--- a/ocdeployer/utils.py
+++ b/ocdeployer/utils.py
@@ -10,6 +10,7 @@ import os
 import yaml
 from functools import reduce
 
+from anytree import Node, RenderTree
 import sh
 from sh import ErrorReturnCode
 from wait_for import wait_for, TimedOutError
@@ -75,6 +76,19 @@ def object_merge(old, new, merge_lists=True):
             else:
                 object_merge(value, new[key])
     return new
+
+
+def traverse_keys(d, keys, default=None):
+    """
+    Allows you to look up a 'path' of keys in nested dicts without knowing whether each key exists
+    """
+    key = keys.pop(0)
+    item = d.get(key, default)
+    if len(keys) == 0:
+        return item
+    if not item:
+        return default
+    return traverse_keys(item, keys, default)
 
 
 def parse_restype(string):
@@ -639,14 +653,81 @@ def cancel_builds(bc_name):
             oc("delete", "build", build_name)
 
 
-def traverse_keys(d, keys, default=None):
+def get_input_image(buildconfig, trigger):
     """
-    Allows you to look up a 'path' of keys in nested dicts without knowing whether each key exists
+    Look up the image stream input image for a build triggered by imagechange.
     """
-    key = keys.pop(0)
-    item = d.get(key, default)
-    if len(keys) == 0:
-        return item
-    if not item:
-        return default
-    return traverse_keys(item, keys, default)
+    bc = buildconfig
+    input_image = None
+
+    if trigger["imageChange"] != {}:
+        # the image used for trigger is explicitly defined, we're done
+        input_image = trigger["imageChange"]["from"]["name"]
+        return input_image
+
+    # we need to look up the image used for trigger in the bc's configuration
+    # check if there's a dockerfile with FROM line
+    dockerfile = traverse_keys(bc, ["spec", "source", "dockerfile"])
+    if dockerfile:
+        for line in dockerfile.splitlines():
+            if line.startswith("FROM"):
+                input_image = line.split()[1]
+                if ":" not in input_image:
+                    input_image = f"{input_image}:latest"
+                break
+
+    # check if the source imagestreamtag is defined in the strategy config
+    for key in ["dockerStrategy", "sourceStrategy", "customStrategy"]:
+        from_kind = traverse_keys(bc, ["spec", "strategy", key, "from", "kind"], "").lower()
+        if from_kind == "imagestreamtag":
+            input_image = bc["spec"]["strategy"][key]["from"]["name"]
+
+    return input_image
+
+
+def get_linked_builds(buildconfigs):
+    """
+    Analyze build configurations to find which builds are 'linked'.
+
+    Linked builds are those which output to an ImageStream that another BuildConfig then
+    uses as its 'from' image.
+
+    Returns a list of Node instances which are parent nodes
+    """
+    bcs_using_input_image = {}
+    bc_creating_output_image = {None: None}
+    node_for_bc = {}
+    for bc in buildconfigs:
+        bc_name = bc["metadata"]["name"]
+        node_for_bc[bc_name] = Node(bc_name)
+
+        # look up output image
+        if traverse_keys(bc, ["spec", "output", "to", "kind"], "").lower() == "imagestreamtag":
+            output_image = bc["spec"]["output"]["to"]["name"]
+            bc_creating_output_image[output_image] = bc_name
+
+        # look up input image
+        for trigger in traverse_keys(bc, ["spec", "triggers"], []):
+            if trigger["type"].lower() == "imagechange":
+                input_image = get_input_image(bc, trigger)
+                if input_image not in bcs_using_input_image:
+                    bcs_using_input_image[input_image] = []
+                bcs_using_input_image[input_image].append(bc_name)
+
+    # attach each build to its parent build
+    for input_image, bc_names in bcs_using_input_image.items():
+        for bc_name in bc_names:
+            parent_bc = bc_creating_output_image.get(input_image)
+            if parent_bc:
+                node_for_bc[bc_name].parent = node_for_bc[parent_bc]
+
+    rendered_trees = []
+    root_nodes = [n for _, n in node_for_bc.items() if n.is_root]
+    for root_node in root_nodes:
+        for pre, _, node in RenderTree(root_node):
+            rendered_trees.append(f"{pre}{node.name}")
+
+    if rendered_trees:
+        log.info("build config tree:\n\n%s", "\n".join(rendered_trees))
+
+    return root_nodes

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,5 @@ appdirs
 wait_for
 jinja2
 cached_property
+anytree
 -e .

--- a/setup.py
+++ b/setup.py
@@ -21,8 +21,16 @@ setup(
     setup_requires=["setuptools_scm"],
     include_package_data=True,
     install_requires=[
-        "sh", "prompter", "pyyaml", "click", "appdirs", "wait_for", "jinja2", "cached_property",
-        "pytz", "kubernetes"
+        "sh",
+        "prompter",
+        "pyyaml",
+        "click",
+        "appdirs",
+        "wait_for",
+        "jinja2",
+        "cached_property",
+        "pytz",
+        "kubernetes",
     ],
     classifiers=[
         "Topic :: Utilities",


### PR DESCRIPTION
When BuildConfigs are deployed, `ocdeployer` will run `oc start-build` on each one

In cases where BuildConfigs are "linked" together (meaning that an output image from one build is used as an input image for the next), this leads to multiple rounds of builds (the first one occurring when `ocdeployer` calls `oc start-build`, and the second one occurring when the ImageChangeTrigger fires once that BuildConfig's parent build has completed)

We will now analyze the deployed BuildConfigs to determine if any of them are linked. We'll only run `oc start-build` for the root build in the hierarchy, and then wait for all of its child builds to complete.