### PR TITLE
Support for concurrent deploys of sets within a stage

### DIFF
--- a/ocdeployer/__main__.py
+++ b/ocdeployer/__main__.py
@@ -109,7 +109,7 @@ def main():
     logging.basicConfig(
         level=logging.INFO,
         datefmt="%Y-%m-%d %H:%M:%S",
-        format="%(asctime)s %(levelname)8s [%(threadName)20s] %(message)s",
+        format="%(asctime)s %(levelname)8s [%(threadName)-15.15s] %(message)s",
     )
     logging.getLogger("sh").setLevel(logging.CRITICAL)
 
@@ -161,6 +161,13 @@ _common_options = [
         "-c",
         is_flag=True,
         help="Deploy service sets within a stage concurrently using thread pool",
+    ),
+    click.option(
+        "--threadpool-size",
+        "-z",
+        type=int,
+        default=os.cpu_count(),
+        help="Threadpool size when running concurrent deploys (default: os.cpu_count()",
     ),
 ]
 
@@ -278,6 +285,7 @@ def deploy_dry_run(
     to_dir,
     jinja_only,
     concurrent,
+    threadpool_size,
 ):
     template_dir, env_config_handler, specific_components, sets_selected, _ = _parse_args(
         template_dir, env_values, env_files, all_services, sets, pick, dst_project
@@ -299,6 +307,7 @@ def deploy_dry_run(
         dry_run=True,
         dry_run_opts={"output": output, "to_dir": to_dir, "jinja_only": jinja_only},
         concurrent=concurrent,
+        threadpool_size=threadpool_size,
     ).run()
 
 
@@ -352,6 +361,7 @@ def deploy_to_project(
     skip,
     watch,
     concurrent,
+    threadpool_size,
 ):
     root_custom_dir = get_dir(root_custom_dir, "custom", "custom scripts", optional=True)
 
@@ -392,6 +402,7 @@ def deploy_to_project(
         skip=skip.split(",") if skip else None,
         dry_run=False,
         concurrent=concurrent,
+        threadpool_size=threadpool_size,
     ).run()
 
     if watch and event_watcher:

--- a/ocdeployer/deploy.py
+++ b/ocdeployer/deploy.py
@@ -567,7 +567,7 @@ class DeployRunner(object):
 
         log.info("deploy service sets in this stage concurrently")
 
-        with concurrent.futures.ThreadPoolExecutor() as executor:
+        with concurrent.futures.ThreadPoolExecutor(max_workers=os.cpu_count()) as executor:
             futures = {
                 executor.submit(self._deploy_service_set, service_set): service_set
                 for service_set in service_sets_selected

--- a/ocdeployer/deploy.py
+++ b/ocdeployer/deploy.py
@@ -578,7 +578,7 @@ class DeployRunner(object):
                     all_processed_templates[service_set] = future.result()
                 except Exception as exc:
                     log.exception("Service set '%s' hit exception", service_set)
-                failed_sets.append(service_set)
+                    failed_sets.append(service_set)
 
         if failed_sets:
             log.error("deploys failed for service set(s): %s", ", ".join(failed_sets))

--- a/ocdeployer/deploy.py
+++ b/ocdeployer/deploy.py
@@ -572,13 +572,13 @@ class DeployRunner(object):
                 executor.submit(self._deploy_service_set, service_set): service_set
                 for service_set in service_sets_selected
             }
-        for future in concurrent.futures.as_completed(futures):
-            service_set = futures[future]
-            try:
-                all_processed_templates[service_set] = future.result()
-            except Exception as exc:
-                log.exception("Service set '%s' hit exception", service_set)
-            failed_sets.append(service_set)
+            for future in concurrent.futures.as_completed(futures):
+                service_set = futures[future]
+                try:
+                    all_processed_templates[service_set] = future.result()
+                except Exception as exc:
+                    log.exception("Service set '%s' hit exception", service_set)
+                failed_sets.append(service_set)
 
         if failed_sets:
             log.error("deploys failed for service set(s): %s", ", ".join(failed_sets))
@@ -633,16 +633,14 @@ class DeployRunner(object):
                     )
                     continue
                 service_sets_selected.append(service_set)
-
-            if not service_sets_selected:
-                raise ValueError("No service sets selected for deploy")
+                at_least_one_set_selected = True
 
             if self.concurrent:
                 all_processed_templates.update(
                     self._deploy_sets_concurrently(service_sets_selected)
                 )
             else:
-                for service_set in selected_service_sets:
+                for service_set in service_sets_selected:
                     all_processed_templates[service_set] = self._deploy_service_set(service_set)
 
         if self.dry_run:

--- a/ocdeployer/deploy.py
+++ b/ocdeployer/deploy.py
@@ -565,7 +565,10 @@ class DeployRunner(object):
         all_processed_templates = {}
         failed_sets = []
 
-        log.info("deploy service sets in this stage concurrently")
+        log.info(
+            "deploying service sets (%s) in this stage concurrently",
+            ", ".join(service_sets_selected)
+        )
 
         with concurrent.futures.ThreadPoolExecutor(max_workers=os.cpu_count()) as executor:
             futures = {

--- a/ocdeployer/deploy.py
+++ b/ocdeployer/deploy.py
@@ -567,7 +567,7 @@ class DeployRunner(object):
 
         log.info(
             "deploying service sets (%s) in this stage concurrently",
-            ", ".join(service_sets_selected)
+            ", ".join(service_sets_selected),
         )
 
         with concurrent.futures.ThreadPoolExecutor(max_workers=os.cpu_count()) as executor:

--- a/ocdeployer/events.py
+++ b/ocdeployer/events.py
@@ -17,6 +17,7 @@ class EventWatcher(threading.Thread):
         config.load_kube_config()
         self._watcher = None
         self.namespace = namespace
+        self.name = "event_watcher"
         self.v1_client = client.CoreV1Api()
 
     def get_all_events(self, _events=None, _continue=None):

--- a/ocdeployer/utils.py
+++ b/ocdeployer/utils.py
@@ -496,25 +496,22 @@ def _wait_with_periodic_status_check(timeout, key, restype, name):
     time_remaining = timeout
 
     def _ready():
-		nonlocal time_last_logged, time_remaining
+        nonlocal time_last_logged, time_remaining
 
-		j = get_json(restype, name)
-		if _check_status_for_restype(restype, j):
-			return True
+        j = get_json(restype, name)
+        if _check_status_for_restype(restype, j):
+            return True
 
-		if time.time() > time_last_logged + 60:
-			time_remaining -= 60
-			if time_remaining:
-				log.info("[%s] waiting %dsec longer", key, time_remaining)
-				time_last_logged = time.time()
-		return False
+        if time.time() > time_last_logged + 60:
+            time_remaining -= 60
+            if time_remaining:
+                log.info("[%s] waiting %dsec longer", key, time_remaining)
+                time_last_logged = time.time()
+        return False
 
-	wait_for(
-		_ready,
-		timeout=timeout,
-		delay=5,
-		message="wait for '{}' to be ready".format(key),
-	)
+    wait_for(
+        _ready, timeout=timeout, delay=5, message="wait for '{}' to be ready".format(key),
+    )
 
 
 def wait_for_ready(restype, name, timeout=300, exit_on_err=False, _result_dict=None):

--- a/ocdeployer/utils.py
+++ b/ocdeployer/utils.py
@@ -224,6 +224,7 @@ def _exec_oc(*args, **kwargs):
     _stderr_log_prefix = kwargs.pop("_stderr_log_prefix", " |stderr| ")
 
     kwargs["_bg"] = True
+    kwargs["_bg_exc"] = False
 
     err_lines = []
     out_lines = []
@@ -242,11 +243,11 @@ def _exec_oc(*args, **kwargs):
     retries = 3
     last_err = None
     for count in range(1, retries + 1):
+        cmd = sh.oc(*args, **kwargs, _tee=True, _out=_out_line_handler, _err=_err_line_handler)
+        if not _silent:
+            cmd_args, cmd_kwargs = _get_logging_args(args, kwargs)
+            log.info("running (pid %d): oc %s %s", cmd.pid, cmd_args, cmd_kwargs)
         try:
-            cmd = sh.oc(*args, **kwargs, _tee=True, _out=_out_line_handler, _err=_err_line_handler)
-            if not _silent:
-                cmd_args, cmd_kwargs = _get_logging_args(args, kwargs)
-                log.info("running (pid %d): oc %s %s", cmd.pid, cmd_args, cmd_kwargs)
             return cmd.wait()
         except ErrorReturnCode as err:
             # Sometimes stdout/stderr is empty in the exception even though we appended


### PR DESCRIPTION
Using `--concurrent/-c` at runtime will enable concurrent deploys. Each stage will still deploy sequentially, but the service sets inside the stage will be handled with a thread pool.

Using `--threadpool-size/-z` allows you to change the worker pool size. Default is `os.cpu_count()`