### PR TITLE
Use threading lock on secret/image imports

### DIFF
--- a/ocdeployer/deploy.py
+++ b/ocdeployer/deploy.py
@@ -585,7 +585,7 @@ class DeployRunner(object):
                 service_set = futures[future]
                 try:
                     all_processed_templates[service_set] = future.result()
-                except Exception:
+                except (Exception, SystemExit):
                     log.exception("Service set '%s' hit exception", service_set)
                     failed_sets.append(service_set)
 

--- a/ocdeployer/images.py
+++ b/ocdeployer/images.py
@@ -1,9 +1,11 @@
 import logging
+import threading
 
 from .utils import oc, get_json, validate_list_of_strs
 
 
 log = logging.getLogger("ocdeployer.images")
+lock = threading.Lock()
 
 
 # Template of an ImageStream config that 'oc import-image' will create
@@ -165,7 +167,8 @@ def _get_args(config, env_names):
 def import_images(config, env_names):
     """Import the specified images listed in a _cfg.yml"""
     for args in _get_args(config, env_names):
-        ImageImporter.do_import(*args)
+        with lock:
+            ImageImporter.do_import(*args)
 
 
 def get_is_configs(config, env_names):

--- a/ocdeployer/secrets.py
+++ b/ocdeployer/secrets.py
@@ -3,6 +3,7 @@ Handles secrets
 """
 import json
 import logging
+import threading
 
 from ocviapy import export
 
@@ -10,6 +11,7 @@ from .utils import oc, get_cfg_files_in_dir, get_json, load_cfg_file, validate_l
 
 
 log = logging.getLogger(__name__)
+lock = threading.Lock()
 
 
 def parse_secret_file(path):
@@ -167,7 +169,8 @@ def import_secrets(config, env_names):
     secrets = parse_config(config)
     for secret in secrets:
         if not secret["envs"] or any([e in env_names for e in secret["envs"]]):
-            SecretImporter.handle(**secret)
+            with lock:
+                SecretImporter.handle(**secret)
         else:
             log.info(
                 "Skipping check/import of secret '%s', not enabled for this env", secret["name"]

--- a/tests/test_deploy.py
+++ b/tests/test_deploy.py
@@ -591,7 +591,8 @@ def test__get_variables_multiple_envs_precedence(patch_os_path):
     }
 
     runner = patched_runner(
-        ["test_env1", "test_env2"], build_mock_env_loader(base_var_data, service_set_var_data),
+        ["test_env1", "test_env2"],
+        build_mock_env_loader(base_var_data, service_set_var_data),
     )
     assert runner._get_variables("service", "templates/service", "component") == expected
 
@@ -610,6 +611,7 @@ def test__get_variables_multiple_envs_precedence_reversed(patch_os_path):
     }
 
     runner = patched_runner(
-        ["test_env2", "test_env1"], build_mock_env_loader(base_var_data, service_set_var_data),
+        ["test_env2", "test_env1"],
+        build_mock_env_loader(base_var_data, service_set_var_data),
     )
     assert runner._get_variables("service", "templates/service", "component") == expected


### PR DESCRIPTION
Multiple threads can run `oc apply` at the same time and run into an `AlreadyExists` error